### PR TITLE
add prog year MeSH - fix typo

### DIFF
--- a/additional-information/mesh/add-mesh-to-course-objective.md
+++ b/additional-information/mesh/add-mesh-to-course-objective.md
@@ -18,7 +18,7 @@ An example of adding a MeSH term to a Course Objective is shown below.
 
 ![Select the MeSH Term](../../.gitbook/assets/add_mesh4.jpg)
 
-MeSH terms may be associated with Courses, Sessions, Learning Materials, and Learning Objectives \(at any level - Program, Course, or Session\).
+MeSH terms may be associated with Courses, Sessions, Learning Materials, and Learning Objectives \(at any level - Program Year, Course, or Session\).
 
 To select a MeSH term from the thesaurus, type in the word or phrase you wish to find, and hit ‘enter’ using your keyboard. The results will display all related concepts, terms and topics, along with their associated descriptor and tree node codes; at the top will display a list of those which have previously been returned and used for similar searches. Clicking a term will add it to the MeSH vocabulary for your selected item. Click the green confirmation button once all terms have been added.
 


### PR DESCRIPTION
This simply fixes a typo where objectives were associated with Program rather than Program Year. Program Year is correct.