### PR TITLE
replace the LG selector screen shot

### DIFF
--- a/courses-and-sessions/offerings/edit-offering.md
+++ b/courses-and-sessions/offerings/edit-offering.md
@@ -80,4 +80,6 @@ The full capability to edit the offering becomes available without having to nav
 
 **Inline Offering Editor (bottom)**
 
-New screen shot coming -- old one removed.
+![](<../../images/updateLG_Offg_11_14_22.png>)
+
+See above for reference on how to select or de-select any individual group in a tree. This same technique can be applied in the location depicting which groups are attached to any given offering. 


### PR DESCRIPTION
updated the screen shot and added some relevant text - starting the process of documenting the Shift click technique for selecting or de-selecting nested learner groups