### PR TITLE
remove link to MyReports

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -52,7 +52,6 @@ These Dashboard View Options are ...
 
 Other functional areas available in all Dashboard views ...
 
-* [**My Reports**](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/my-reports)
 * [**My Courses**](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/my-courses)
 * [**Global Search**](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/search)
 


### PR DESCRIPTION
This was in the Dashboard section - just as an FYI. Removing the link to MyReports.