### PR TITLE
removed_my_courses_from_TOC

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -12,7 +12,6 @@
   * [Calendar Feed Options](dashboard/calendar-feed-options.md)
   * [Calendar View Options](dashboard/calendar-view-options.md)
   * [Calendar Search & Filter Options](dashboard/calendar-search-and-filter-options.md)
-  * [My Courses](dashboard/my-courses.md)
   * [My Profile](dashboard/my-profile.md)
   * [Reports](dashboard/reports.md)
   * [Language Selector](dashboard/language-selector.md)


### PR DESCRIPTION
fixes #150 - this removes the reference to `my_courses` from the table of contents contained in the file `SUMMARY.md` - also closes the associated issue - *NOTE* - the files remain in the `user_guide` repo but are no longer displayed anywhere - eventually will clean up