### PR TITLE
final update - teaching-reminders.md

### DIFF
--- a/courses-and-sessions/offerings/teaching-reminders.md
+++ b/courses-and-sessions/offerings/teaching-reminders.md
@@ -2,11 +2,11 @@
 
 ### Teaching Reminders
 
-These are email messages sent out \(as configured at UCSF\) so that all instructors receive the reminder 7 days prior to the teaching event.
+These are email messages sent out (as configured at UCSF) so that all instructors receive the reminder 7 days prior to the teaching event.
 
 The [email template](https://iliosproject.gitbook.io/ilios-user-guide/additional-information/alert-and-email-templates) can be modified to meet your school's needs.
 
-Below is a screen shot roughly showing what a teaching reminder might look like to an instructor. It includes Learner information \(Groups and/or Individuals\) assigned to the Offering. 
+Below is a screen shot roughly showing what a teaching reminder might look like to an instructor. It includes Learner information (Groups and/or Individuals) assigned to the Offering. 
 
 ![Teaching reminder sample](../../images/teaching_reminders/reminder_example.png)
 


### PR DESCRIPTION
After a full rebase and a botched pull request, this is just a couple of simple text changes and confirmation of the location and name of the correctly linked file in `courses-and-sessions/offerings/teaching-reminders.md` - new image location `images/teaching_reminders`.