### PR TITLE
deleted_some_outdated_text

### DIFF
--- a/dashboard/materials-view.md
+++ b/dashboard/materials-view.md
@@ -1,6 +1,6 @@
 # Materials View
 
-With the Materials view, all Learning Materials which have Offerings within the next 60 days are displayed initially. This can be changed to display "[All Materials](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/materials-view#all-materials)" - everything associated with this this student's educational trajectory. [**My Reports**](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/my-reports) **** and **** [**My Courses**](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/my-courses) **** can be accessed from here as well. They are available underneath the Materials View since we are still on the Dashboard. It is important to note that if there is no value displayed in the "Session" column, these are Course level materials and do not pertain to any specific session.
+With the Materials view, all Learning Materials which have Offerings within the next 60 days are displayed initially. This can be changed to display "[All Materials](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/materials-view#all-materials)" - everything associated with this this student's educational trajectory. It is important to note that if there is no value displayed in the "Session" column, these are Course level materials and do not pertain to any specific session.
 
 **NOTE**: Since this pertains exclusively to "Learning Materials", these materials apply only to Students. Instructors and Course Directors will not see any Learning Materials here.
 
@@ -8,7 +8,7 @@ With the Materials view, all Learning Materials which have Offerings within the 
 
 Clicking as shown above on "Materials" brings up the Learning Materials the student will be using for the offerings occurring at any point in the next 60 days. "All Materials" can be toggled here which will have the same window but with all Learning Materials the student has ever encountered. Pagination helps load these Learning Materials up quite quickly.
 
-![](<../images/materials_view_start.png>)
+![Materials View - starting point](<../images/materials_view_start.png>)
 
 Clicking on the title of the Learning Material will route the user to be able to access and / or download the Learning Material file, link, or citation. If it is a link, the web site will open. Citations are displayed in completeness right there and there is nothing to click or follow. Files will be downloaded to the user's computer.
 
@@ -18,7 +18,7 @@ Below is a screen shot similar to the one above but this time displaying the stu
 
 "All Materials" has been selected instead of the default "Next 60 days".
 
-![](<../images/materials_view_all.png>)
+![Materials for next 60 days](<../images/materials_view_all.png>)
 
 ## Sort Options
 


### PR DESCRIPTION
Page affected: `https://iliosproject.gitbook.io/ilios-user-guide/dashboard/materials-view`

At first, I found some formatting issues and then later realized that the links were expired / removed from the guide. My Reports and My Courses are both gone at this point so no links or references to them should exist in the guide. This PR is a leftover from removing them - there may still be more.