### PR TITLE
attempted to updated unpublished icon 3rd try

### DIFF
--- a/dashboard/calendar-view.md
+++ b/dashboard/calendar-view.md
@@ -42,6 +42,10 @@ It is important to note that non-students Ilios users **WILL** see offerings for
 
 Icon indicating "Not Published" status: 
 
+![Unpublished Icon](../images/unpubiished_icon.png)
+
+Testing ...
+
 <figure>
   <img src="../images/unpublished_icon.png" alt="Unpublished icon">
     <figcaption>


### PR DESCRIPTION
This is sort of a test PR to see if either approach leads to the revealing and display of the `unpublished_icon.png` image file - a small one to be sure - to appear. Whichever method (full HTML) or traditional image link in markdown works will be the victor. If neither works, I will figure out how to replace the image and see what happens next.