### PR TITLE
attempted to updated unpublished icon final try

### DIFF
--- a/dashboard/calendar-view.md
+++ b/dashboard/calendar-view.md
@@ -44,15 +44,6 @@ Icon indicating "Not Published" status:
 
 ![Unpublished Icon](../images/unpubiished_icon.png)
 
-Testing ...
-
-<figure>
-  <img src="../images/unpublished_icon.png" alt="Unpublished icon">
-    <figcaption>
-      <p>Unpublished</p>
-    </figcaption>
-</figure>
-
 ![A few tips ...](../images/calendar_tips.png)
 
 ### CSS Override


### PR DESCRIPTION
I think this may do it. I'm not using the HTML block, which wasn't displaying the image correctly either. However, redoing and relinking the original seemed to do the trick - this PR gets rid of the HTML block and refreshed the original image link which now seems to appear correctly.

`dashboard/calendar-view.md` is the page affected by this -- image file is `../images/unpubiished_icon.png`

