### PR TITLE
added modifed spiel from AAMC about curriculum inventory

### DIFF
--- a/curriculum-inventory/README.md
+++ b/curriculum-inventory/README.md
@@ -1,5 +1,7 @@
 # Curriculum Inventory
 
+IMPORTANT NOTE: The AAMC will no longer collect curriculum data through the AAMC Curriculum Inventory Portal. For the 2022-2023 academic year and beyond, they will collect curriculum data through a new survey. Questions? Please contact [curriculum@aamc.org](mailto:curriculum@aamc.org).
+
 ## Curriculum Inventory Manager
 
 The Curriculum Inventory Manager is designed to allow Ilios users to craft standards-compliant xml output reports for the AAMC’s new Curriculum Inventory, as well as to provide a platform for modeling new frameworks for the curricula held in Ilios.


### PR DESCRIPTION
I added an introductory spiel to the now much harder to find "Curriculum Inventory" page in the user guide.

This covers the expiration of the CI Upload functionality which is no longer supported by the AAMC.

* user guide page affected by this PR ... `curriculum-inventory/README.md`
