### PR TITLE
updating my-courses.md and reports.md with new image locations

### DIFF
--- a/older_files/my-courses.md
+++ b/older_files/my-courses.md
@@ -6,10 +6,10 @@ This area on the Dashboard displays all upcoming or current Courses associated w
 
 This is demonstrated below showing how it works while being logged in as an Instructor.
 
-![](<../images/my_courses/my_courses_list.png>)
+![](../older_files/my_courses/my_courses_list.png)
 
 Clicking on the Course Title (Renal, Endocrine, GI, Nutrition) takes the user to the Course Detail screen for the selected Course as shown below.
 
-![](<../images/my_courses/my_courses_detail.png>)
+![](../older_files/my_courses/my_courses_detail.png)
 
 **NOTE:** To return to the Dashboard, the back button on the browser can be used. Alternatively, the "Back to Courses List" link will take you back to the Courses page.

--- a/older_files/reports.md
+++ b/older_files/reports.md
@@ -6,13 +6,13 @@ The My Reports section on the Dashboard allows users to create and save quickly 
 
 My Reports is available on the Dashboard in the lower left portion of the screen as shown below. It is available whether or not the Calendar is being displayed.
 
-![](../.gitbook/assets/my_reports_1.jpg)
+![](../older_files/my_reports/my_reports_1.jpg)
 
 The custom reports in My Reports have auto-generated names but you can override this and provide your own name if you prefer.
 
 Review the "All Instructors for Foundations of Patient Care Year 2 \(2016-17\)" by clicking on the link to display the following data.
 
-![](../.gitbook/assets/report_output.jpg)
+![](../older_files/my_reports/report_output.jpg)
 
 ## Create A Custom Report
 
@@ -20,13 +20,13 @@ To create a custom report, click the \(+\) icon to start the process. Refer to t
 
 The following interface appears once the \(+\) icon has been clicked.
 
-![](../.gitbook/assets/new_report.jpg)
+![](../older_files/my_reports/new_report.jpg)
 
 One final field appears when more information is needed.
 
-![](../.gitbook/assets/new_report_2.jpg)
+![](../older_files/my_reports/new_report_2.jpg)
 
 Once "Save" is clicked, a new report will be generated with the title "All Instructors for PRIME 2016-17 in Medicine" as shown below.
 
-![](../.gitbook/assets/new_report_3.jpg)
+![](../older_files/my_reports/new_report_3.jpg)
 


### PR DESCRIPTION
* markdown user guide files affected by this PR ... `my-courses.md` and `reports.md`
* these have been moved in previous PR to the following location ... `older_files` - why? because they are no longer in use
* links fixed up on these removed pages just to get the images out of gitbook and to notate where the files have been moved to ...
