### PR TITLE
more info on session level instructional notes

### DIFF
--- a/courses-and-sessions/sessions/edit-session.md
+++ b/courses-and-sessions/sessions/edit-session.md
@@ -85,7 +85,7 @@ After being saved, the link appears as shown below in "display" (post-save) mode
 
 ### Instructional Notes
 
-The process for editing and entering Instructional Notes is basically identical to the process detailed above for session description. One difference is that Instructional Notes do not get truncated in the interface if lengthy.
+The process for editing and entering Instructional Notes is basically identical to the process detailed above for session description. 
 
 **NOTE**: Session-level instructional notes do **not** appear on Event Detail or anywhere in the Calendar or feed. They are used internally and are accessible only through Courses and Sessions. These are notes that can be left by Course Administrators for instructors or other Administrative users to review.
 


### PR DESCRIPTION
* page affected by / involved with this PR ... `courses-and-sessions/sessions/edit-session.md`

I needed to remove the part about a difference between Instructional Notes and Session Description which does not exist. Removed the untrue content.