### PR TITLE
event detail update - fixed title case of image file

### DIFF
--- a/dashboard/event-detail-view.md
+++ b/dashboard/event-detail-view.md
@@ -14,4 +14,4 @@ Links in the screen shot - explained below
 
 After clicking as shown above, the user is routed to the Event Detail of the ILM entitled "Histology of the Cardiovascular System". This event is pre-requisite for the Session "Response of the Heart to Injury".
 
-![ILM Event View - due before ...](../images/event_detail/ILM_Detail.png)
+![ILM Event View - due before ...](../images/event_detail/ILM_detail.png)


### PR DESCRIPTION
related to #361 - new image added had a name I wanted to fix to match the rest of the naming conventions used for the image files so `ILM_Detail` is now `ILM_detail`