### PR TITLE
trying to get rid of bad asterisks in ILM section

### DIFF
--- a/courses-and-sessions/sessions/independent-learning-module-ilm.md
+++ b/courses-and-sessions/sessions/independent-learning-module-ilm.md
@@ -4,8 +4,8 @@ ILM's are a specific type of Session which does not necessarily meet in any part
 
 These are displayed in one of two places ...
 
-1. ****[**ILM with Due Date / Time**](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions/independent-learning-module-ilm#ilm-with-due-date-time)**:** An ILM will appear on the Calendar at the specified time on the Due Date that was assigned. It shows up in a fifteen minute block on the Calendar regardless of the actual duration of the expected activity. If a time is not specified, the default is 5pm.
-2. ****[**ILM linked to an Upcoming Session Offering**](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions/independent-learning-module-ilm#ilm-linked-to-session): An ILM that is linked to an upcoming Session will have the learning activities listed on the target session in all places session offerings appear in Ilios, among them on [Week at a Glance](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/week-at-a-glance).
+1. [**ILM with Due Date / Time**](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions/independent-learning-module-ilm#ilm-with-due-date-time): An ILM will appear on the Calendar at the specified time on the Due Date that was assigned. It shows up in a fifteen minute block on the Calendar regardless of the actual duration of the expected activity. If a time is not specified, the default is 5pm.
+2. [**ILM linked to an Upcoming Session Offering**](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions/independent-learning-module-ilm#ilm-linked-to-session): An ILM that is linked to an upcoming Session will have the learning activities listed on the target session in all places session offerings appear in Ilios, among them on [Week at a Glance](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/week-at-a-glance).
 
 An example of #2 is shown below. The icon indicating that an ILM is linked to another session is shown below.
 


### PR DESCRIPTION
```
modified:   courses-and-sessions/sessions/independent-learning-module-ilm.md
```

I notice some preceding asterisks which need to be removed. Hopefully this PR will do this. I will be testing this later as well as I am redoing the `Course and Sessions` chapters.