### PR TITLE
quick markdown typo fix

### DIFF
--- a/courses-and-sessions/courses/edit-parent-objective.md
+++ b/courses-and-sessions/courses/edit-parent-objective.md
@@ -2,7 +2,7 @@
 
 Course objectives can have one or more associations with parent (program year) objectives. This is configurable at the school level whether to allow multiple or just one to be attached.
 
-## Parent Objecctive Updates
+## Parent Objective Updates
 
 * Select an Objective to change its association to its Parent Objective
 


### PR DESCRIPTION
`modified:   courses-and-sessions/courses/edit-parent-objective.md`

A mis-spelled word and header needs to be fixed. That is happening here.