### PR TITLE
added an introduction to the chapter - reuse elsewhere

### DIFF
--- a/courses-and-sessions/courses/sort-objectives.md
+++ b/courses-and-sessions/courses/sort-objectives.md
@@ -1,3 +1,7 @@
+---
+description: Course objectives can be sorted so that the presentation of the objectives occurs in a user-specified order.
+---
+
 # Sort Objectives
 
 This is now accomplished in a similar manner to the sorting of Learning Materials, as well as Program Year Objectives and Session Objectives. This allows instructional designers to determine a priority ranking of Objectives to be presented to students.


### PR DESCRIPTION
`modified:   courses-and-sessions/courses/sort-objectives.md`

There is a way to add an "introduction" to any chapter / page in the user guide - it looks like and is helpful to the user - will use this same technique in many or most chapters.