### PR TITLE
a cpl of fixes - current year rollover only

### DIFF
--- a/courses-and-sessions/courses/course-rollover.md
+++ b/courses-and-sessions/courses/course-rollover.md
@@ -38,15 +38,15 @@ Here is the newly created Course.
 
 ## Current Year
 
-A Course may be easily rolled over into the current year. There is one simple caveat. Two Courses cannot exist in the same year with the exact same Title so it is necessary to change the name of the Course in order to roll it over into the same (current) year.
+A Course may be easily rolled over into the current year. There is one simple caveat. Two Courses cannot exist in the same year with the exact same title so it is necessary to change the name of the Course in order to roll it over into the same (current) year.
 
 To do this ...
 
-* Select a Course that needs to be rolled over into the Current year.
+* Select a Course that needs to be rolled over into the current year.
 
 ![select course](../../images/course_rollover/same_year_rollover_1.jpg)
 
-* Click on the Rollover Icon to start the process.
+* Click on the Rollover icon to start the process.
 
 ![click the rollover icon](../../images/course_rollover/same_year_rollover_2.jpg)
 


### PR DESCRIPTION
```
On branch fix_up_course_rollover_current_year_starting_pt
Changes to be committed:
        modified:   courses-and-sessions/courses/course-rollover.md
```

This is just a quick one to remind myself to fix up current year course rollover with new screen shots soon. Fixed a cpl of capitalization errors here - I'm leaning towards fewer unnecessary "proper" nouns when they are not indeed proper.