### PR TITLE
trimmed intro to attach course LM - there is a max

### DIFF
--- a/courses-and-sessions/courses/attach-learning-materials.md
+++ b/courses-and-sessions/courses/attach-learning-materials.md
@@ -1,5 +1,5 @@
 ---
-description: Learning Materials may be attached to courses or sessions. In order to be used with Ilios, materials must be tagged with certain additional information - a display name, owner and copyright information. Adding these elements is covered below.
+description: Learning Materials may be attached to courses or sessions. In order to be used with Ilios, materials must be tagged with certain additional information. This is covered below.
 ---
 
 The first step is to select a Course and also to click "Show Details" to reveal the Course Details - of which Learning Materials is one. These steps are covered in other parts of the guide.


### PR DESCRIPTION
```
On branch fix_up_attach_course_LM_intro
Changes to be committed:

        modified:   courses-and-sessions/courses/attach-learning-materials.md
```

I was not aware of this until now but there is a maximum length of any given page's "introduction" section. This PR trims the introduction section of the above referenced page to fit.