### PR TITLE
made student advisor label into header

### DIFF
--- a/courses-and-sessions/courses/course-leadership.md
+++ b/courses-and-sessions/courses/course-leadership.md
@@ -4,7 +4,9 @@
 
 Course Leadership is part of the new permissions model. Course Directors, Course Administrators, and Student Advisors are added here. Course **Directors** and **Administrators**  have similar rights - to maintain any and all aspects of this Course. It is a matter of specifying whether the user is an administrative user using Ilios to maintain the Course or if the user is actually a Director. 
 
-**Student Advisors** are able to download any and all Learning Materials from a Course to which they have been given this role. They will need to navigate the Calendar in order to access these resources. In other words, their Week at a Glance, Activities, and calendar feed will NOT contain all of the learning events of their assigned Courses; but the Learning Materials will be available for them to review to assist other students.
+## Student Advisors
+
+Users given the role of Student Advisor are able to download any and all Learning Materials from a Course to which they have been given this role. They will need to navigate the Calendar in order to access these resources. In other words, their Week at a Glance, Activities, and calendar feed will NOT contain all of the learning events of their assigned Courses; but the Learning Materials will be available for them to review to assist other students.
 
 Refer to the [permissions matrix](https://www.dropbox.com/s/431sdj2bfoi3v1f/Ilios%20New%20Default%20Permissions%20Matrix.pdf?dl=0) for more information on these updated permissions. After exposing the Course Details, Course Leadership is the next functional area below the Course Summary Details section.
 


### PR DESCRIPTION
```
On branch promote_student_advisor_to_header
Changes to be committed:
        modified:   courses-and-sessions/courses/course-leadership.md
```

In order to make this a bit more prominent, at least at Course level, I made the "Student Advisor" label into H2 or in markdown "##".