### PR TITLE
shortening intro spiel to fit into alloted space

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ---
-description: Ilios is a curriculum management platform for the Health Professions educational community. It is a user-friendly, flexible, and robust web application. Ilios collects, manages, analyzes, and delivers curricular information.
+description: Ilios is a curriculum management platform for the Health Professions educational community. It is a user-friendly, flexible, and robust web application used to collect, manage, and deliver curricular information.
 ---
 For an introduction to Ilios and to sign up for newsletters and announcements, click [here](https://www.iliosproject.org/about/).
 


### PR DESCRIPTION
```
On branch fix_introduction_to_guide
Changes to be committed:
        modified:   README.md
```

I noticed the previous intro sentence was too long to fit into the allotted space. It may require a second round of truncation but let's try this for now.