### PR TITLE
fixed short title text link - edit program page

### DIFF
--- a/programs/edit-program.md
+++ b/programs/edit-program.md
@@ -3,7 +3,7 @@
  As far as the Program itself is concerned, the fields that can be modified are listed below. Editing any of these fields will have long reaching effects.
 
 * [Title](https://iliosproject.gitbook.io/ilios-user-guide/programs/edit-program#edit-program-title)
-* [Short Title)](https://iliosproject.gitbook.io/ilios-user-guide/programs/edit-program#add-edit-short-title)
+* [Short Title](https://iliosproject.gitbook.io/ilios-user-guide/programs/edit-program#add-edit-short-title)
 * [Duration (in years)](https://iliosproject.gitbook.io/ilios-user-guide/programs/edit-program#change-program-duration-years)
 * [Leadership](https://iliosproject.gitbook.io/ilios-user-guide/programs/edit-program#program-leadership) - (add/remove Directors)
 


### PR DESCRIPTION
```
On branch fix_short_title_text_link
Changes to be committed:

        modified:   programs/edit-program.md
```

There was a bad link with an extra out parenthesis character that needed to be removed. This PR does that.