### PR TITLE
updated instructor group description

### DIFF
--- a/instructor-groups/README.md
+++ b/instructor-groups/README.md
@@ -2,6 +2,8 @@
 
 The Instructor Groups module in Ilios allows for the creation of reusable and trackable sets of instructors that can be associated to course/session activity. The groups are populated from the existing directory of active Ilios users, and can be modified and added to as needed. An instructor may be associated with any number of instructor groups, or none at all. Instructors and instructor groups are associated with course content at the offering level for each session (session offering(s)) or they can be attached to Independent Learning Modules (ILM's).
 
+**NOTE:** Instructor Groups persist throughout the years. There is no need to "rollover" an Instructor Group. They can be used in any year chosen.
+
 ## Quick Links
 
 * [Add Instructor Group](https://iliosproject.gitbook.io/ilios-user-guide/instructor-groups/add-instructor-group)

--- a/instructor-groups/README.md
+++ b/instructor-groups/README.md
@@ -2,7 +2,7 @@
 
 The Instructor Groups module in Ilios allows for the creation of reusable and trackable sets of instructors that can be associated to course/session activity. The groups are populated from the existing directory of active Ilios users, and can be modified and added to as needed. An instructor may be associated with any number of instructor groups, or none at all. Instructors and instructor groups are associated with course content at the offering level for each session (session offering(s)) or they can be attached to Independent Learning Modules (ILM's).
 
-**NOTE:** Instructor Groups persist throughout the years. There is no need to "rollover" an Instructor Group. They can be used in any year chosen.
+**NOTE:** Instructor Groups persist throughout the years. There is no need to "rollover" an Instructor Group. They can be used in any year chosen. Basically, they exist in perpetuity. In this way, they differ from Learner Groups.
 
 ## Quick Links
 


### PR DESCRIPTION
```
On branch update_instructor_group_description
Changes to be committed:
        modified:   instructor-groups/README.md
```

A bit was added here to include details on how instructor groups do not need to be rolled over or re-created and how they exist in perpetuity.