### PR TITLE
added link to offering editor calendar - navigation

### DIFF
--- a/courses-and-sessions/offerings/create-single-offering.md
+++ b/courses-and-sessions/offerings/create-single-offering.md
@@ -4,7 +4,9 @@
 
 The same process as the creation of Small Group Offerings can be performed in reverse where a number of sub-groups can all be invited to the same event. To demonstrate, we will use the same group as in the "Small Groups" example and create one event for them all to attend. This process is shown below.
 
-As indicated below, the Offerings Editor Calendar is initially hidden. To display it and to review the scheduling of this offering as well as all other offerings involving the same learner groups, click Show Calendar.
+As indicated below, the Offerings Editor Calendar is initially hidden. To display it and to review the scheduling of this offering as well as all other offerings involving the same learner groups, click [Show Calendar](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/offerings/offerings-editor-calendar). 
+
+When displayed, the calendar will appear above the controls for editing date / time and other offering attributes.
 
 ### Scheduling
 


### PR DESCRIPTION
```
On branch add_link_to_offerings_editor_calendar
Changes to be committed:
        modified:   courses-and-sessions/offerings/create-single-offering.md
```

Added information about the positioning of the offerings editor calendar on the page.
