### PR TITLE
poorly placed asterisks on this page - fixed to match pattern

### DIFF
--- a/schools/vocabularies.md
+++ b/schools/vocabularies.md
@@ -6,7 +6,7 @@ Managing Vocabularies and Terms at the School level is performed using the Schoo
 
 * ****[**Session**](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions)****
 * ****[**Course**](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/courses)****
-* ****[**Objective**](https://iliosproject.gitbook.io/ilios-user-guide/glossary#objective) (Course, Session, Program Year)&#x20;
+* ****[**Objective**](https://iliosproject.gitbook.io/ilios-user-guide/glossary#objective) (Course, Session, Program Year)****
 * ****[**Program Year**](https://iliosproject.gitbook.io/ilios-user-guide/programs/add-program-year#program-year-attributes)****
 
 ![Expand vocabularies](../images/schools/vocabularies/expand_vocabularies.jpg)


### PR DESCRIPTION
```
On branch fix_typo_in_schools_vocabularies
Changes to be committed:
        modified:   schools/vocabularies.md
```

