### PR TITLE
chapter name change - school leadership >> leadership

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -75,7 +75,7 @@
   * [Delete Instructor Group](instructor-groups/delete-instructor-group.md)
 * [Schools](schools/README.md)
   * [Add New School](schools/add-new-school.md)
-  * [School Leadership](schools/school-leadership.md)
+  * [Leadership](schools/school-leadership.md)
   * [Competencies](schools/competencies.md)
   * [Vocabularies](schools/vocabularies.md)
   * [Session Types](schools/session-types.md)


### PR DESCRIPTION
``` modified:   SUMMARY.md```

Updated the chapter for Schools >> "School Leadership" to be simply "Leadership". The remaining aspect of this chapter - images and text - will be updated later this week. This reflects recent naming convention updates in the interface.