### PR TITLE
link fixed - print summary

### DIFF
--- a/courses-and-sessions/courses/course-summary.md
+++ b/courses-and-sessions/courses/course-summary.md
@@ -6,7 +6,7 @@ The Course Print Summary provides a complete view of a Course: all details for a
 
 The top-most portion of the Print Summary is displayed below. All Sessions and all of the associated data can be found by scrolling down.
 
-![Print Summary Screen - top](../../images/course_summary/course_print_summary_top.jpg)
+![Print Summary Screen - top](../../images/course_summary/course_print_summary_top.png)
 
 After generating the printabler course summary for any course, it can be saved as .html using "Save As". Alternatively, you can choose "Print" and point it to save and download as .pdf. These controls may be in different places but in Chrome, these instructions apply. The documents can be searched outside of Ilios itself and only containing the information that pertains to the course selected.
 


### PR DESCRIPTION
```
On branch fix_image_link_course_summary_top
Changes to be committed:
        modified:   courses-and-sessions/courses/course-summary.md
```

I screwed up and forgot to fix the link in the related PR #560 - I replaced the image but forgot to fix the page that links to it. This PR fixes that issue.