### PR TITLE
removed link to py obj vizualization

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -87,7 +87,6 @@
   * [Edit Program](programs/edit-program.md)
   * [Program Years](programs/add-program-year.md)
   * [Competency Map Download](programs/competency-map-download.md)
-  * [Program Year Objective Visualization](programs/program-year-objective-map-visualization.md)
 * [Reports](reports/reports.md)
 * [Admin](admin/README.md)
   * [View All](admin/view-all.md)


### PR DESCRIPTION
```* [Program Year Objective Visualization](programs/program-year-objective-map-visualization.md)```

The line above used to be in the `SUMMARY.md` file. The page is still there but hidden in case we bring it back.

```
On branch hide_program_year_objective_viz_page
Changes to be committed:
        modified:   SUMMARY.md
```


![image](https://github.com/ilios/user-guide/assets/7493331/bd9b99cd-8c28-42e2-a33f-294534ba8df7)
