### PR TITLE
toggle not light bulb - description added

### DIFF
--- a/programs/add-program-year.md
+++ b/programs/add-program-year.md
@@ -62,7 +62,7 @@ This shows where the Program Year objectives (graduation requirements) have been
 
 Below is a sample screen shot illustrating this. The Program Year Objective "MK2 (graduation) ..." has been expanded by clicking the arrow to the left of the Objective. Viewable are the Courses in which this was taught along with the text values of the associated Course Objectives.
 
-Any, or all, of these Program Year Objectives can be expanded individually to reveal these useful details.
+Any, or all, of these Program Year Objectives can be expanded individually to reveal these useful details. The toggles for activating / de-acitivating program year objectives are in read-only mode when the selection is expanded. The blue one in the screen shot below is ready for use.
 
 ![Program year objective detail](../images/programs/program_years/program_year_objective_detail.png)
 


### PR DESCRIPTION
This PR is an attempt to explain why the activation / de-activation toggles for PY objectives are not usable in expanded mode.