### PR TITLE
got rid of duplicated page header

### DIFF
--- a/courses-and-sessions/courses/edit-objective.md
+++ b/courses-and-sessions/courses/edit-objective.md
@@ -1,5 +1,3 @@
-## Edit Objective
-
 The text value (description) of a Course Objective can be easily edited inline style here on the Course page. Also relationships to parent objectives, vocabulary terms, and MeSH terms can easily be maintained here as well. To do this ...
 
 ### Select a Course


### PR DESCRIPTION
```
On branch add_headers_for_attach_vocab_terms_to_crs_obj
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   courses-and-sessions/courses/edit-objective.md
```

I realized there was a duplicated header at the top of the page - trying to better organize the headers on this page to flow better. This is hopefully just a first step in that process.