### PR TITLE
fixed course list flattened all to H2

### DIFF
--- a/courses-and-sessions/courses/create-new-course.md
+++ b/courses-and-sessions/courses/create-new-course.md
@@ -1,4 +1,4 @@
-## New Course
+## Start the Process
 
 Courses are unique to the academic year in which they are taught and the school within which they are created. To create a new course, click the **Add New** button, and provide a course name and select the appropriate year of instruction.
 
@@ -8,7 +8,7 @@ The process of adding a new course to Ilios gets initiated from the Course list,
 
 **NOTE:** Just because "2023" is currently selected from the year drop-down does not mean the new course needs to be in the academic year "2023". This can be selected during the course creation process. 
 
-### Create New Course
+## Create New Course
 
 ![adding new course](../../images/course_images/add_new_course.png)
 
@@ -16,19 +16,19 @@ After clicking **Done** as shown in the example shown above, the remaining detai
 
 Since multiple cohorts can be added to any course, even if the additional cohorts are from a different program or school, there is no direct connection between Course and Program; however, all Courses are saved within a selected school when originaly created.
 
-### New Course Saved
+## New Course Saved
 
 ![new course saved](../../images/course_images/new_course_saved.png)
 
 After clicking the link as shown above, the screen appears as follows with the New Course being appropriately titled **Drugs And Side Effects 101**. The Course is initially saved with a state of **Not Published** since it has no Sessions or Offerings at this point. Since the act of publishing is essentially the equivalent of populating student calendars with their corresponding offerings, there is nothing to publish at this time.
 
-### New Course Details
+## New Course Details
 
 ![new course details](../../images/course_images/new_course_details.png)
 
 After clicking the **Back to Courses List** link, the full list of Courses appears as shown below. It has been filtered by "dr" to limit the results to show the Course we just created. This filtering functionality is covered in greater detail in the next section, [Edit Course](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/courses/edit-course).
 
-### Updated List
+## Updated List
 
 ![updated list](../../images/course_images/filtered_course_list.png)
 


### PR DESCRIPTION
```
On branch fix_double_header_create_new_course_redux
Changes to be committed:
        modified:   courses-and-sessions/courses/create-new-course.md
```

I am actually a bit confused about what shows up when or why. Flattened everything to H2 style headers for testing purposes. May fix this up later but for now -- this PR.