### PR TITLE
added link to sessions main page from course README

### DIFF
--- a/courses-and-sessions/courses/README.md
+++ b/courses-and-sessions/courses/README.md
@@ -25,7 +25,7 @@ This refers to the other attributes of the course that can be maintained only af
   - - **MeSH:** maintain MeSH (Medical Subject Header) terms associated with this course at the course level 
   - - **Program Cohorts:** maintain / manage cohort(s) attached to this course 
 ### Session List
-  - - **Sessions:** a full list of all sessions in the course - many edits to sessions can be performed directly from here at the course level (in-line editing).
+  - - **[Sessions:]**(https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions) a full list of all sessions in the course - many edits to sessions can be performed directly from here at the course level (in-line editing).
 
 ## Course Attributes
 


### PR DESCRIPTION
```
On branch add_link_to_session_list_from_course_README
Changes to be committed:
        modified:   courses-and-sessions/courses/README.md
```

Not sure how well this will work but working on dividing courses into three sections - in this PR, added a link to the session list.