### PR TITLE
heading area course README a third attempt at dashes or bulletpt

### DIFF
--- a/courses-and-sessions/courses/README.md
+++ b/courses-and-sessions/courses/README.md
@@ -10,14 +10,14 @@ There are four main functional areas related to the maintenance and creation of 
 
 This area appears at the top of the Course page. It includes everything listed below. 
 
-  - - ** - Back to Courses list:** link back to list of Courses 
-  - - ** - Title:** can be edited here 
-  - - ** - Publication Status:** This is a drop-down menu containing the options for publishing a course - listed below.
-    - - ** - Not Published:** initial status at course creation time - can be returned to this later by using **UnPublish**
-    - - ** - Publish** or **Publish As-Is:** publishes course 
-    - - ** - Review Missing Items:** takes user to area to review desired or required items for course publication
-    - - ** - Mark as Scheduled:** sets course to `Scheduled` status
-    - - ** - UnPublish:** only available if course has been published - reverts course to `Not Published` status 
+  - - **- Back to Courses list:** link back to list of Courses 
+  - - **- Title:** can be edited here 
+  - - **- Publication Status:** This is a drop-down menu containing the options for publishing a course - listed below.
+    - - **- Not Published:** initial status at course creation time - can be returned to this later by using **UnPublish**
+    - - **- Publish** or **Publish As-Is:** publishes course 
+    - - **- Review Missing Items:** takes user to area to review desired or required items for course publication
+    - - **- Mark as Scheduled:** sets course to `Scheduled` status
+    - - **- UnPublish:** only available if course has been published - reverts course to `Not Published` status 
 
 ### Overview
 


### PR DESCRIPTION
```
On branch update_course_overview_heading_vs_details_README
Changes to be committed:
        modified:   courses-and-sessions/courses/README.md
```

made sure that the dash is directly next to the bold so it takes effect - learning how to best do this - may require yet another effort after this one 