### PR TITLE
tinkering with vertical space heading alignments two

### DIFF
--- a/courses-and-sessions/courses/README.md
+++ b/courses-and-sessions/courses/README.md
@@ -3,7 +3,9 @@
 A Course is a Curricular object that defines the content and structure of a specific instance of coursework available to the school or program.
 
 There are four main functional areas related to the maintenance and creation of Courses in Ilios. These are detailed below and follow the vertical navigational flow through the page.
+
 ## Functional Areas
+
 ### Heading 
 
 This area appears at the top of the Course page. It includes everything listed below. 


### PR DESCRIPTION
```                                         
On branch make_it_easier_to_read_in_design_mode
Changes to be committed:
        modified:   courses-and-sessions/courses/README.md
```

I was doing some testing as far as which vertical space adjustments would appear in the markdown output and if it even made a difference. It appears it does not make a difference so I am reverting the previous changes and going with the easiest format to read in design mode since the output is not directly affected.