### PR TITLE
removed dash from courses README - needed to be removed

### DIFF
--- a/courses-and-sessions/courses/README.md
+++ b/courses-and-sessions/courses/README.md
@@ -12,7 +12,7 @@ This area appears at the top of the Course page. It includes everything listed b
   - **Title:** can be edited here - refers to full title (name) of the course, entered on course creation - 200 character maximum
   - **Publication Status:** This is a drop-down menu containing the options for publishing a course - listed below.
     - **Not Published:** initial status at course creation time - can be returned to this later by using **UnPublish**
-    - **-Publish** or **Publish As-Is:** publishes course 
+    - **Publish** or **Publish As-Is:** publishes course 
     - **Review Missing Items:** takes user to area to review desired or required items for course publication
     - **Mark as Scheduled:** sets course to `Scheduled` status
     - **UnPublish:** only available if course has been published - reverts course to `Not Published` status 


### PR DESCRIPTION
```
On branch fix_uneeded_dash_courses_README
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   courses-and-sessions/courses/README.md
```

Reviewing the courses README.md page, I noticed there was a confusing dash that needed to be removed - this PR fixes that issue.