### PR TITLE
fixed indentation of session list to match other sections

### DIFF
--- a/courses-and-sessions/courses/README.md
+++ b/courses-and-sessions/courses/README.md
@@ -31,6 +31,7 @@ This refers to the upper area of the screen which is always visible. It provides
   - **Universal Locator:** read-only descriptor field containing database ID
 
 ### Detail 
+
 This refers to the other course attributes listed below that can be maintained only after "Show Details" has been clicked.
 
   - **Leadership:** maintain course directors, administrators, and student advisors 
@@ -39,8 +40,10 @@ This refers to the other course attributes listed below that can be maintained o
   - **Competencies:** read-only display of competencies that are linked to the associated program year objectives 
   - **Terms:** maintain vocabulary terms associated with this course at the course level 
   - **MeSH:** maintain MeSH (Medical Subject Header) terms associated with this course at the course level 
-  - **Program Cohorts:** maintain / manage cohort(s) attached to this course 
+  - **Program Cohorts:** maintain / manage cohort(s) attached to this course
+
 ### Session List
+
   - [**Sessions:**](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions) a full list of all sessions in the course - many edits to sessions can be performed directly from here at the course level (in-line editing).
 
 ## Course Attributes

--- a/courses-and-sessions/courses/README.md
+++ b/courses-and-sessions/courses/README.md
@@ -41,7 +41,7 @@ This refers to the other course attributes listed below that can be maintained o
   - **MeSH:** maintain MeSH (Medical Subject Header) terms associated with this course at the course level 
   - **Program Cohorts:** maintain / manage cohort(s) attached to this course 
 ### Session List
-  - - [**Sessions:**](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions) a full list of all sessions in the course - many edits to sessions can be performed directly from here at the course level (in-line editing).
+  - [**Sessions:**](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions) a full list of all sessions in the course - many edits to sessions can be performed directly from here at the course level (in-line editing).
 
 ## Course Attributes
 


### PR DESCRIPTION
```
On branch update_session_header_indentations
Changes to be committed:
        modified:   courses-and-sessions/courses/README.md
```

Related to #658 in the sense I am fixing up the final section to get them all to match format-wise.