### PR TITLE
updated one more link to leadership not school leadership

### DIFF
--- a/courses-and-sessions/courses/course-leadership.md
+++ b/courses-and-sessions/courses/course-leadership.md
@@ -12,7 +12,7 @@ Refer to the [permissions matrix](https://www.dropbox.com/s/431sdj2bfoi3v1f/Ilio
 
 Clicking on Course Leadership opens up the details for this Course and allows modification of this leadership. As shown below, click **Manage Leadership** to add or remove Course Leadership - Directors, Administrators, and / or Student Advisors.
 
-# Manage Course Leadership
+# Click to Manage
 
 ![click to manage](../../images/course_leadership/crs_ldrshp2.png)
 


### PR DESCRIPTION
```
On branch change_caption_to_manage_leadership_no_school
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   courses-and-sessions/courses/course-leadership.md
```

I actually updated the link to `Click to Manage` since this is the first step only and it is actually more accurately stated this way.