### PR TITLE
remove parentheses from link to leadership

### DIFF
--- a/courses-and-sessions/courses/README.md
+++ b/courses-and-sessions/courses/README.md
@@ -34,7 +34,7 @@ This refers to the upper area of the screen which is always visible. It provides
 
 This refers to the other course attributes listed below that can be maintained only after "Show Details" has been clicked.
 
-  - **([Leadership](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/courses/course-leadership)):** maintain course directors, administrators, and student advisors 
+  - **[Leadership](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/courses/course-leadership):** maintain course directors, administrators, and student advisors 
   - **Objectives:** maintain / manage objectives and their relationships to parent (program year) objectives, vocabulary terms, and MeSH terms
   - **Learning Materials:** upload and / or link learning materials at the course level
   - **Competencies:** read-only display of competencies that are linked to the associated program year objectives 


### PR DESCRIPTION
```
On branch remove_parentheses_from_leadership_link
Changes to be committed:
        modified:   courses-and-sessions/courses/README.md
```

This cleans up the formatting of the previous PR #674 - can use this going forward to link to more sections.