### PR TITLE
fixed truncated introduction on learning_materials.md page

### DIFF
--- a/courses-and-sessions/courses/learning_materials.md
+++ b/courses-and-sessions/courses/learning_materials.md
@@ -1,3 +1,3 @@
 ---
-description: Learning Materials may be attached to courses or sessions. In order to be used with Ilios, materials must be tagged with certain additional information. This is covered in the chapters contained below.
+description: Learning Materials may be attached to courses or sessions. In order to be used with Ilios, materials must be tagged with certain additional information. This is covered in the upcoming chapters.
 ---


### PR DESCRIPTION
```
On branch fix_text_in_new_course_lm_page_fix_typo
Changes to be committed:
        modified:   courses-and-sessions/courses/learning_materials.md
```

I think the `introduction` header types have a text maximum, which I had exceeded. This PR truncates this back down to be below the maximum text length.