### PR TITLE
created introduction section on course_objectives.md

### DIFF
--- a/courses-and-sessions/courses/add-objective.md
+++ b/courses-and-sessions/courses/add-objective.md
@@ -1,5 +1,7 @@
 # Add New Objective
 
+Objectives are the desired learning or teaching outcomes for a given curricular object. These may be Program Year Objectives (also referred to as graduation requirements), Course level learning Objectives, or Session level teaching Objectives. Objectives may be associated with Competencies, which are linked as parents to Program Year Objectives.
+
 To enter a Course level Objective ...
 
 * Select a Course and open up the details.

--- a/courses-and-sessions/courses/course_objectives.md
+++ b/courses-and-sessions/courses/course_objectives.md
@@ -1,3 +1,3 @@
-# Course Objectives
-
-Objectives are the desired learning or teaching outcomes for a given curricular object. These may be Program Year Objectives (also referred to as graduation requirements), Course level learning Objectives, or Session level teaching Objectives. Objectives may be associated with Competencies, which are linked as parents to Program Year Objectives.
+---
+description: Objectives may be attached to courses, sessions, or program years. This process is covered in subsequent chapers.
+---


### PR DESCRIPTION
```
On branch update_objectives_new_page_with_introduction
Changes to be committed:
        modified:   courses-and-sessions/courses/add-objective.md
        modified:   courses-and-sessions/courses/course_objectives.md
```

I realized that if a parent page contains only an "introduction", the subsequent pages appear with links automatically on the main page - I like this - trying to have course objectives get the same treatment as learning materials with this PR.