### PR TITLE
fixed typo in introduction section on course_objectives.md

### DIFF
--- a/courses-and-sessions/courses/course_objectives.md
+++ b/courses-and-sessions/courses/course_objectives.md
@@ -1,3 +1,3 @@
 ---
-description: Objectives may be attached to courses, sessions, or program years. This process is covered in subsequent chapers.
+description: Objectives may be attached to courses, sessions, or program years. This process is covered in the chapters listed below.
 ---


### PR DESCRIPTION
```
On branch fix_text_in_introduction_course_objectives
Changes to be committed:
        modified:   courses-and-sessions/courses/course_objectives.md
```

