### PR TITLE
attempting to add link to crs obj definition

### DIFF
--- a/courses-and-sessions/courses/course_objectives.md
+++ b/courses-and-sessions/courses/course_objectives.md
@@ -1,3 +1,3 @@
 ---
-description: Objectives may be attached to courses, sessions, or program years. This process is covered in the chapters listed below.
+description: [Objectives](https://iliosproject.gitbook.io/ilios-user-guide/glossary#objective) may be attached to courses, sessions, or program years. This process is covered in the chapters listed below.
 ---


### PR DESCRIPTION
```
On branch add_link_to_objective_definition_course_obj_level
Changes to be committed:
        modified:   courses-and-sessions/courses/course_objectives.md
```

This may not actually work due to how `definition` works. Either the link may not work or there are too many characters involved due to the URL. May end up reverting but need to try this out for future page updates here and in other places.