### PR TITLE
attempting to add link to crs obj definition only a test

### DIFF
--- a/courses-and-sessions/courses/course_objectives.md
+++ b/courses-and-sessions/courses/course_objectives.md
@@ -1,3 +1,3 @@
 ---
-description: [Objectives](https://iliosproject.gitbook.io/ilios-user-guide/glossary#objective) may be attached to courses, sessions, or program years. This process is covered in the chapters listed below.
+description: [Objectives](https://iliosproject.gitbook.io/ilios-user-guide/glossary#objective) may dartajax be attached to courses, sessions, or program years. This process is covered in the chapters listed below.
 ---


### PR DESCRIPTION
```
On branch edit_link_to_objective_definition_course_obj_level
Changes to be committed:
        modified:   courses-and-sessions/courses/course_objectives.md
```

This is only a test and will be reverted. The previous PR #696 never seemed to get processed so I added some nonsense here to make sure changes are being pushed out.