### PR TITLE
attempting to edit link to crs obj definition again

### DIFF
--- a/courses-and-sessions/courses/course_objectives.md
+++ b/courses-and-sessions/courses/course_objectives.md
@@ -1,3 +1,3 @@
 ---
-description: Objectives can be attached to courses, sessions, or program years. This process is covered in the chapters listed below. 
+description: Objectives can be attached to courses, sessions, or program years. This process is covered in the chapters listed below [link](https://iliosproject.gitbook.io/ilios-user-guide/glossary#objective)
 ---

--- a/courses-and-sessions/courses/course_objectives.md
+++ b/courses-and-sessions/courses/course_objectives.md
@@ -1,3 +1,3 @@
 ---
-description: Objectives can be attached to courses, sessions, or program years. This process is covered in the chapters listed below [link](https://iliosproject.gitbook.io/ilios-user-guide/glossary#objective)
+description: Objectives can be attached to courses, sessions, or program years. This process is covered in the chapters listed below - [link](https://iliosproject.gitbook.io/ilios-user-guide/glossary#objective).
 ---


### PR DESCRIPTION
```                                                           
On branch add_link_to_objective_definition_course_obj_level_redux
Changes to be committed:
        modified:   courses-and-sessions/courses/course_objectives.md
```

Straight up added "link" to the end of the "definition" of objective - need to see if this is possible - changes are being pushed - I know this because of the previous PR changing "may" to "can" did get pushed through. 