### PR TITLE
removed link that didnt work - lame

### DIFF
--- a/courses-and-sessions/courses/course_objectives.md
+++ b/courses-and-sessions/courses/course_objectives.md
@@ -1,3 +1,3 @@
 ---
-description: Objectives can be attached to courses, sessions, or program years. This process is covered in the chapters listed below - [link](https://iliosproject.gitbook.io/ilios-user-guide/glossary#objective).
+description: Objectives can be attached to courses, sessions, or program years. This process is covered in the chapters listed below.
 ---


### PR DESCRIPTION
```                                                      
On branch remove_link_didnt_work
Changes to be committed:
        modified:   courses-and-sessions/courses/course_objectives.md
```

The title says it all. I guess if I want to use the cool buttons that get provided when there is no text on the main page but there is a short introduction (which doesn't seem to allow links for some reason), I will have to put the links elsewhere.