### PR TITLE
updated link in school vocab for program years - point to root

### DIFF
--- a/schools/vocabularies.md
+++ b/schools/vocabularies.md
@@ -7,7 +7,7 @@ Managing Vocabularies and Terms at the School level is performed using the Schoo
 * ****[**Session**](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions)****
 * ****[**Course**](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/courses)****
 * ****[**Objective**](https://iliosproject.gitbook.io/ilios-user-guide/glossary#objective) (Course, Session, Program Year)****
-* ****[**Program Year**](https://iliosproject.gitbook.io/ilios-user-guide/programs/add-program-year#program-year-attributes)****
+* ****[**Program Year**](https://iliosproject.gitbook.io/ilios-user-guide/programs/add-program-year)****
 
 ![Expand vocabularies](../images/schools/vocabularies/expand_vocabularies.jpg)
 


### PR DESCRIPTION
```
On branch fix_program_year_link_in_school_vocabularies
Changes to be committed:
        modified:   schools/vocabularies.md
```

I realized that the link pointing to program years from within the schools/vocabularies.md file was not pointing correctly to the root of program years. This PR fixes that.