### PR TITLE
updated link in dashboard materials view to activity check boxes

### DIFF
--- a/dashboard/materials-view.md
+++ b/dashboard/materials-view.md
@@ -15,7 +15,7 @@ Clicking on the title of the Learning Material will route the user to be able to
 ### Status - Learning Material activity check boxes
 Learning Material activity check boxes are included here as well. All three states are shown in the screen shot above. 
 
-Refer to [Event Detail](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/materials-view#status-learning-material-activity-check-boxes) for detailed information regarding the usage of these check boxes. This information gets shared anywhere Learning Materials are accessed by students in Ilios.
+Refer to [Event Detail](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/event-detail-view#learning-material-activity-check-boxes) for detailed information regarding the usage of these check boxes. This information gets shared anywhere Learning Materials are accessed by students in Ilios.
 
 ## All Materials
 


### PR DESCRIPTION
```
On branch fix_link_to_activity_check_boxes_materials-view.md
Changes to be committed:
        modified:   dashboard/materials-view.md
```

The link on this page to demonstrate the learning materials activity check boxes as they pertain to event detail was basically a circular loop taking the user basically nowhere. This PR fixes that.