### PR TITLE
updated cohort assignment process in admin console

### DIFF
--- a/admin/user-account-and-role-management.md
+++ b/admin/user-account-and-role-management.md
@@ -102,6 +102,8 @@ Both students and non-students may be assigned into any number of “secondary�
 
 To assign a user a secondary cohort, click the “edit” button beneath the user cohort information listing on their account information page. Select any available program cohort from the list provided in the picker, and save. The assignment will now be shown on the user’s page.
 
+**NOTE:** Adding a cohort to any user's profile will result in the newly added cohort being added as a secondary cohort. This applies whether or not the user has been assigned a primary cohort. If one of these secondary cohorts needs to be selected as the primary cohort, this can here as described elsewhere in this section. The newly promoted cohort will simply replace any previously assigned primary cohort. The previous primary will become a secondary cohort.
+
 ### Access Control and Permissions
 
 Ilios provides a management interface to allow for the simple control of edit – level permissions for existing users and their access to curricular data. Combined with the option of joint program stewardship, these permissions provide an extremely powerful mechanism for creating and deploying interdisciplinary curricula.


### PR DESCRIPTION
```
On branch make_sure_secondary_cohort_added_first
Changes to be committed:
        modified:   admin/user-account-and-role-management.md
```

I added a note to the page listed above to advise that newly added cohorts are always added as secondary cohorts and need to be promoted to primary status if that is the case.