### PR TITLE
removed link to glossary since target was same as text

### DIFF
--- a/courses-and-sessions/sessions/README.md
+++ b/courses-and-sessions/sessions/README.md
@@ -1,6 +1,6 @@
-# Sessions
+## Sessions
 
-**DESCRIPTION** (see [Glossary](https://iliosproject.gitbook.io/ilios-user-guide/glossary#session)): A session refers to a section or unit of a course with specific attributes of type and content. Sessions may be represented as multiple or singular time and place Offerings or as Independent Learning units with an estimated duration of educational time. Sessions (generally Independent Learning Modules (ILM's)) can be associated with a follow-up Session. These learning activities should be completed before the follow-up takes place, or by a specified Due Date and time.
+A session refers to a section or unit of a course with specific attributes of type and content. Sessions may be represented as multiple or singular time and place Offerings or as Independent Learning units with an estimated duration of educational time. Sessions (generally Independent Learning Modules (ILM's)) can be associated with a follow-up Session. These learning activities should be completed before the follow-up takes place, or by a specified Due Date and time.
 
 ### Session Attributes (all session types)
 


### PR DESCRIPTION
There was no reason to have a link to take the reader to a different location to read the same information - link removed - description of session kept as is.