### PR TITLE
quick typo fix plural form of noun missing

### DIFF
--- a/courses-and-sessions/README.md
+++ b/courses-and-sessions/README.md
@@ -1,6 +1,6 @@
 # Courses and Sessions
 
-Clicking on the Courses and Sessions menu item pulls up the screen for maintaining both Course and Sessions within Ilios. The interface in Ilios allows for a great deal of information to be displayed and editable at the top level. Please refer to the following sections for more information. Courses are displayed initially. You can drill down into Sessions, Offerings, and can update Publishing status of both Courses and Sessions.
+Clicking on the Courses and Sessions menu item pulls up the screen for maintaining both Courses and Sessions in Ilios. The interface in Ilios allows for a great deal of information to be displayed and editable at the top level. Please refer to the following sections for more information. Courses are displayed initially. You can drill down into Sessions, Offerings, and can update Publishing status of both Courses and Sessions.
 
 ## [Courses](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/courses)
 


### PR DESCRIPTION
```
On branch fix_typo_plural_needed
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   courses-and-sessions/README.md
```