### PR TITLE
updated caption to event detail not updated since not applicable

### DIFF
--- a/dashboard/event-detail-view.md
+++ b/dashboard/event-detail-view.md
@@ -12,7 +12,7 @@ The screen shot below starts the process for a student to access the Event Detai
 * **Response of the Heart to Injury** - This is the post-requisite to the ILM listed above. User will be taken to Event Detail for the offering when clicked.
 * **ABC Course Wrap-up** - Another scheduled activity for this Learner.
 
-### Updated Event Detail
+### Event Detail displayed
 
 ![Updated Event Detail](../images/event_detail/updated_event_detail.png)
 


### PR DESCRIPTION
```                                                              
On branch caption_update
Changes to be committed:
        modified:   dashboard/event-detail-view.md
```

The caption "Updated Event Detail" was not really applicable because the text section has nothing to do with "updated" in this case. This PR fixes that.