### PR TITLE
added link to school competencies setup

### DIFF
--- a/courses-and-sessions/courses/competencies.md
+++ b/courses-and-sessions/courses/competencies.md
@@ -1,1 +1,3 @@
 Competencies are configured at the School level in Ilios but assigned at the Program Year level. They are in read-only mode at the Course level. The screen shot for this along with links and more discussion will be coming soon.
+
+Setting up compentencies a the school level for use in Ilios is covered [here](https://iliosproject.gitbook.io/ilios-user-guide/schools/competencies).


### PR DESCRIPTION
```
On branch more_work_on_competencies_course_level
Changes to be committed:
        modified:   courses-and-sessions/courses/competencies.md
```

The course competency page is still hidden - added a link to the school competency setup.