### PR TITLE
added a bit more descriptive text on competency fixed

### DIFF
--- a/courses-and-sessions/courses/competencies.md
+++ b/courses-and-sessions/courses/competencies.md
@@ -6,4 +6,4 @@ Setting up compentencies a the school level for use in Ilios is covered [here](h
 
 ![displayed list](../../images/course_competencies/course_competency_list.png)
 
-This list displays the competencies that have been configured for the cohort assigned to this course. The commpetencies are set up at the program year level.
+These commpetencies are set up at the program year level. The list at the course level displays all of those competencies that have been mapped via `course objective >> program year objective` mapping. The program year objectives have been mapped to school competencies or else the competencies would not appear on this list.


### PR DESCRIPTION
```
On branch more_work_on_competencies_course_level_fix_prev
Changes to be committed:
        modified:   courses-and-sessions/courses/competencies.md
```

This fixes the text entered and added in #786 which was factually inaccurate. Only competencies that have been actually mapped to program year objectives and course objectives are actually displayed on the course page.