### PR TITLE
added a bit of text for description of help link

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -28,7 +28,7 @@ When the Ilios application is not being viewed at full size or is being viewed u
   </figcaption>
 </figure>
 
-The **Ilios Menu expander** is only available in the smaller view of the toolbar. It is not needed in full-size mode.
+The **Ilios Menu expander** is only available in the smaller view of the toolbar. It is not needed in full-size mode. The **Help Link** is always available and takes the user directly to this very guide.
 
 ### Small Screen View - expanded
 


### PR DESCRIPTION
Added a spiel to the `dashboard/README.md` page - it needed to be pointed out that the help link to the user guide is always available - in any screen size.