### PR TITLE
updated link to .ics feed

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -5,6 +5,7 @@ Once logged in, you will be presented with the “Dashboard” or landing page, 
 The Dashboard is designed to provide quick access to common sets of information and simple task and activity tracking. Navigation is performed by using the Ilios Menu, which appears on the upper left part of the screen and can be accessed and expanded by clicking “Ilios Menu” as shown below. It is a fly away menu that expands once it has been clicked and is available even if you have scrolled down the page. If your screen has enough viewable area, the **Ilios Menu** will appear automatically as shown below. Ilios users who do not perform non-learner activities (i.e. students who are not also Instructors, Course Directors, Course Administrators, or Student Advisors) will not see the Ilios Menu shown below.
 
 ## Ilios Flyout Menu
+
 ### Large Screen View
 The view below is of the Ilios flyout menu on a relatively large screen. This is how it will appear for Admin users unless they use a smaller screen, tablet, or smart phone.
 

--- a/dashboard/icons-explained.md
+++ b/dashboard/icons-explained.md
@@ -56,7 +56,7 @@ The link to the Ilios Help Guide is available to all Ilios users. It is always a
 ### Link to .ics feed
 ![Copy My ICS Link](../images/icons_explained/ics_feed_link.png)
 
-This button is conveniently located just to the right of the "Calendar" button. This is for copying the .ics feed for use in online calendars including Outlook and Google - click for [More Information](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/calendar-view/calendar-feed-options).
+This button is conveniently located just to the right of the "Calendar" button. This is for copying the .ics feed for use in online calendars including Outlook and Google - click for [here](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/calendar-view/calendar-feed-options) for more information.
 
 ## Non-learner Facing Icons
 


### PR DESCRIPTION
* on branch `icons_explained_caps_fix`
* files modified - `README.md`, `icons-explained.md`
* changed link to "here" for more information 
* undid changes from #811 since there now appears to be a vertical spacing issue = too much space all over the guide
