### PR TITLE
fixed typo - added link to edit instructions

### DIFF
--- a/learner-groups/edit-group-properties/edit-group-membership.md
+++ b/learner-groups/edit-group-properties/edit-group-membership.md
@@ -1,8 +1,8 @@
-# Edit Membership
+## Add Learners to Group
 
-## Add Individual Learner to Group
+### Individual Learner
 
-In this example, there are no Learners in the group "Demonstration Group 05". The learner "Lawrence Alvarez" needs to be added to the group. This can be accomplished as shown below.
+In this example, there are no Learners in the group "Demonstration Group 5". The learner "Lawrence Alvarez" needs to be added to the group. This can be accomplished as shown below.
 
 ![No learners yet](../../images/edit_learner_group/group_membership/no_learners_yet.png)
 
@@ -10,7 +10,7 @@ Once the green (+) has been clicked to add "Lawrence Alvarez" to the sub group "
 
 ![Added to the Learner Group](../../images/edit_learner_group/group_membership/learner_added.png)
 
-## Add Multiple Learners to Group
+### Multiple Learners
 
 Users will need to scroll down to the lower part of the screen to access the area where Cohort members who have not been added to Demonstration Group or any of its sub groups is located.
 

--- a/learner-groups/sub-groups.md
+++ b/learner-groups/sub-groups.md
@@ -39,3 +39,5 @@ See below how the screen appears after selecting "Demonstration Group 05".
 ![Sub group selected](../images/sub_groups/sub_group_selected.png)
 
 The check boxes on the left should be used in cases where you want to add multiple people to a group or sub group. In the case where you just want to add one individual person, the green (+) buttons on the right should be utilized.
+
+Click [here](https://iliosproject.gitbook.io/ilios-user-guide/learner-groups/edit-group-properties/edit-group-membership) for more information on editing learner group membership.


### PR DESCRIPTION
```
On branch fix_typo_add_link_lg_membership_edit
Changes to be committed:
        modified:   learner-groups/edit-group-properties/edit-group-membership.md
        modified:   learner-groups/sub-groups.md
```