### PR TITLE
minor text update

### DIFF
--- a/learner-groups/remove-learner-group.md
+++ b/learner-groups/remove-learner-group.md
@@ -6,7 +6,7 @@ If you have been assigned permissions to delete Learner Groups, the trash can ic
 
 ![learner groups can be deleted / removed](../images/delete_learner_group/can_be_deleted_learner_groups.png)
 
-**IMPORTANT NOTE:** Learner Groups can only be deleted if they have not been associated with any Learning Events (ILM's or Offerings), even if members are included or those sessions or course are not published. This is true even if the learner group has sub groups underneath it and those sub groups have learners attached. All that matter is that there are no offerings or ILM's associated with the learner group or any sub groups.
+**IMPORTANT NOTE:** Learner Groups can only be deleted if they have not been associated with any Learning Events (ILM's or Offerings), even if members are included or those sessions or course are not published. This is true even if the learner group has sub groups underneath it and those sub groups have learners attached. All that matter is that there are no offerings or ILM's associated with the learner group or any sub groups. Sub groups will be deleted / removed as well if a parent is removed.
 
 ### Remove Members From Learner Group
 

--- a/learner-groups/remove-learner-group.md
+++ b/learner-groups/remove-learner-group.md
@@ -6,7 +6,7 @@ If you have been assigned permissions to delete Learner Groups, the trash can ic
 
 ![learner groups can be deleted / removed](../images/delete_learner_group/can_be_deleted_learner_groups.png)
 
-**IMPORTANT NOTE:** Learner Groups can only be deleted if they have not been associated with any Learning Events (ILM's or Offerings), even if members are included or those sessions or course are not published.
+**IMPORTANT NOTE:** Learner Groups can only be deleted if they have not been associated with any Learning Events (ILM's or Offerings), even if members are included or those sessions or course are not published. This is true even if the learner group has sub groups underneath it and those sub groups have learners attached. All that matter is that there are no offerings or ILM's associated with the learner group or any sub groups.
 
 ### Remove Members From Learner Group
 


### PR DESCRIPTION
```
On branch one_more_comment_on_learner_group_removal
Changes to be committed:
        modified:   learner-groups/remove-learner-group.md
```

Text added to the above-mentioned file that advises that if even if sub groups have membership, as long as there are no offerings or ILM's attached (published or not), the learner group and any subs can still be deleted / removed from the system.