### PR TITLE
minor text update fixed spelling of accommodation

### DIFF
--- a/learner-groups/learner-group-defaults.md
+++ b/learner-groups/learner-group-defaults.md
@@ -83,7 +83,7 @@ Initially (before being set), the toggle appears as shown below. The default for
 
 Slide the toggle over to the right by clicking it as shown below.
 
-### Slide to Set to Needs Accomodation
+### Slide to Set to Needs Accommodation
 
 ![needs accommodation - slide to set to "Yes"](../images/learner_group_defaults/needs_accom_set_to_yes.png)
 


### PR DESCRIPTION
```
On branch checkout_spelling_of_accommodation
Changes to be committed:
        modified:   learner-groups/learner-group-defaults.md
```

Two m's needed in addition to two c's in long word "accommodation" - this PR fixes this.