### PR TITLE
added a bit more text - open .pdf preview course LM disclaimer

### DIFF
--- a/courses-and-sessions/courses/view-learning-materials.md
+++ b/courses-and-sessions/courses/view-learning-materials.md
@@ -28,7 +28,7 @@ A viewing option sample from an older session materials screen shot is shown bel
 
 ## Download File (available for any file)
 
-In the past, this was the default behavior for all files. Now .pdf files have been configured so they can be viewed in an "inline" manner without requiring the file to be downloaded. Any file can be downloaded as shown above by the orange arrow.
+In the past, this was the default behavior for all files. Now .pdf files have been configured so they can be viewed in an "inline" manner without requiring the file to be downloaded. One thing to consider doing this is that if the window gets closed after viewing a .pdf file, you will have to log back in to Ilios as this action closes that application. Any file can be downloaded as shown above by the orange arrow. With .pdf files, they will open up for viewing and be downloaded to your storage device's default.
 
 ## Copy Link (available for any Learning Material)
 


### PR DESCRIPTION
```
On branch another_quick_disclaimer_course_lm_viewing
Changes to be committed:
        modified:   courses-and-sessions/courses/view-learning-materials.md
```

I found this out the hard way - and this applies to viewing LM's in Courses and Sessions >> Course details as well, if you click the view button for a .pdf and then close that window, you will need to re-open Ilios - kind of a pain.