### PR TITLE
added a bit more info about curricular object in glossary

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -18,7 +18,7 @@ Point in educational time / progress within a given program for an individual or
 
 ## Curricular Object
 
-A Program, Course, Session, or Offering.
+A Program, Course, Session, Offering, Independent Learning Module (ILM), or any other object tracked in Ilios as part of the medical school curriculum.
 
 ## Designation
 


### PR DESCRIPTION
```
On branch remove_curricular_object_from_glossary
Changes to be committed:
        modified:   glossary.md
```

I ended not removing, but enhancing, the description of curricular object in the glossary - bad branch name.