### PR TITLE
course MeSH description updated

### DIFF
--- a/courses-and-sessions/courses/README.md
+++ b/courses-and-sessions/courses/README.md
@@ -39,7 +39,7 @@ This refers to the other course attributes listed below that can be maintained o
   - **Learning Materials:** upload and / or link learning materials at the course level
   - **Competencies:** read-only display of competencies that are linked to the associated program year objectives 
   - **[Terms](https://iliosproject.gitbook.io/ilios-user-guide/schools/vocabularies):** maintain vocabulary terms associated with this course
-  - **[MeSH](https://iliosproject.gitbook.io/ilios-user-guide/additional-information/mesh):** maintain MeSH (Medical Subject Header) terms associated with this course at the course level 
+  - **[MeSH](https://iliosproject.gitbook.io/ilios-user-guide/additional-information/mesh):** maintain MeSH (Medical Subject Header) terms associated with this course
   - **Program Cohorts:** maintain / manage cohort(s) attached to this course
 
 ### Session List


### PR DESCRIPTION
```
On branch one_more_update_to_course_MeSH_text
Changes to be committed:
        modified:   courses-and-sessions/courses/README.md
```

Redundant verbiage removed to match other text fixed in #983 