### PR TITLE
fixing verbiage of Ilios menu - navigation not flyout -text rmvd

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -50,7 +50,7 @@ The view of Ilios as seen from a mobile phone or device is very similar to the w
 
 For more details, review [Mobile Device View](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/mobile-devices).
 
-### Flyout Menu Items (all views)
+### Menu Items (all views)
 
 These menu items available in all views include:
 


### PR DESCRIPTION
Working on changing guide to reflect "Navigation" menu rather than "Flyout" menu. Removed an unnecessary instance of "Flyout", which is now out of context and confusing.

On branch `fix_link_nav_rather_than_flyout_menu`

