### PR TITLE
dashboard README update - student advisor role

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -4,7 +4,7 @@ Once logged in, you will be presented with the “Dashboard” or landing page, 
 
 The Dashboard is designed to provide quick access to common sets of information and simple task and activity tracking. Navigation is performed by using the Ilios Menu, which appears on the upper left part of the screen. It is a fly away menu that expands once it has been clicked and is available even if you have scrolled down the page. If your screen has enough viewable area, the **Ilios Navigation Menu** will appear automatically as shown below. 
 
-**NOTE:** Ilios users who do not perform non-learner activities (i.e. students who have not been assigned the role of Instructor, Course Director, Course Administrator, Student Advisor, or any one of the other advanced user roles) will not see the Ilios Navigation Menu shown below.
+**NOTE:** Ilios users who do not perform non-learner activities (i.e. students who have not been assigned the role of Instructor (by association to offerings), Course Director, or Course Administrator) will not see the Ilios Navigation Menu shown below. Student Advisors, if not provided a role with even higher permissions such as any of the ones previously mentioned, will not see the Ilios Navigation Menu.
 
 ## Ilios Navigation Menu
 

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -4,11 +4,11 @@ Once logged in, you will be presented with the “Dashboard” or landing page, 
 
 The Dashboard is designed to provide quick access to common sets of information and simple task and activity tracking. Navigation is performed by using the Ilios Menu, which appears on the upper left part of the screen. It is a fly away menu that expands once it has been clicked and is available even if you have scrolled down the page. If your screen has enough viewable area, the **Ilios Navigation Menu** will appear automatically as shown below. 
 
-**NOTE:** Ilios users who do not perform non-learner activities (i.e. students who have not been assigned the role of Instructor (by association to offerings), Course Director, or Course Administrator) will not see the Ilios Navigation Menu shown below. Student Advisors, if not provided a role with even higher permissions such as any of the ones previously mentioned, will not see the Ilios Navigation Menu.
+**NOTE:** Ilios users who do not perform non-learner activities (i.e. students who have NOT been assigned the role of Instructor (by association to offerings), Course Director or Administrator, Session Administrator, or School-level permissions) will not see the Ilios Navigation Menu shown below. Student Advisors, if not provided a role with even higher permissions such as any of the ones mentioned above, also will not see the Ilios Navigation Menu.
 
 ## Ilios Navigation Menu
 
-This refers to the menu found on the left of the screen in full screen viewing mode. Not all users will see this (explained below). Its appearance varies with different screen sizes or devices. The navigational elements and destinations remain the same regardless of the user's view.
+This refers to the menu found on the left of the screen in full screen viewing mode. Not all users will see this (explained in NOTE above). Its appearance varies with different screen sizes or devices. The navigational elements and destinations remain the same regardless of the user's view.
 
 ### Large Screen View
 The view below is of the Ilios navigation menu on a relatively large screen. This is how it will appear for Admin users unless they use a smaller screen, tablet, or smart phone.


### PR DESCRIPTION
```
On branch update_student_advisor_menu_view
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   dashboard/README.md
```

This PR addresses the fact that users who are assigned a Student Advisor role do not see the Ilios Navigation Menu unless they have been assigned a higher role in the system such as Instructor, Director, or Administrator.