### PR TITLE
added bit about how check boxes on user basis

### DIFF
--- a/dashboard/materials-view.md
+++ b/dashboard/materials-view.md
@@ -15,7 +15,7 @@ Clicking on the title of the Learning Material will route the user to be able to
 ### Status - Learning Material activity check boxes
 Learning Material activity check boxes are included here as well. All three states are shown in the screen shot above. 
 
-Refer to [Event Detail](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/event-detail-view#learning-material-activity-check-boxes) for detailed information regarding the usage of these check boxes. This information gets shared anywhere Learning Materials are accessed by students in Ilios.
+Refer to [Event Detail](https://iliosproject.gitbook.io/ilios-user-guide/dashboard/event-detail-view#learning-material-activity-check-boxes) for detailed information regarding the usage of these check boxes. This information gets displayed anywhere Learning Materials are accessed by students in Ilios. Only the logged-in student will see the check boxes. They are for personalized tracking of learning activity.
 
 **NOTE:** These check boxes only appear for Session-level learning materials. Course-level materials serve more as high-level perennial documentation not related to specific session learning activities (i.e. no check box needed).
 


### PR DESCRIPTION
```
On branch update_check_box_desription_lm_needs_more_work
Changes to be committed:
        modified:   dashboard/materials-view.md
```

I changed the wording since I found the previous information to be inaccurate and misleading. The check box activity is not "shared" - only the logged-in user sees this but will see it throughout the application where learning materials are tracked and displayed. This PR fixes that.