### PR TITLE
added link to vocab term session level caption change

### DIFF
--- a/courses-and-sessions/sessions/edit-session.md
+++ b/courses-and-sessions/sessions/edit-session.md
@@ -132,7 +132,7 @@ Once confirmed in the step shown above, the Manage MeSH functional area closes (
 
 ![More MeSH maintenance](../../images/session_edit/click_for_more_maintenance.png)
 
-## Manage Session Term(s)
+## Manage Vocabulary Terms
 
 Terms are selected a school-specific, pre-defined list of one or more Vocabularies. These can be attached at the Course level and / or at the Session level.
 


### PR DESCRIPTION
```
On branch for_now_add_link_to_session_vocab_maint_caption_update
Changes to be committed:
        modified:   courses-and-sessions/sessions/edit-session.md
```

The link to Manage Session Term(s) wasn't working as well as I had hoped since I was linking from Courses over to Sessions - this PR simplifies the link to hopefully make it be more anchored. We'll see. A follow-up PR to this one will be required once this change shows up.