### PR TITLE
fixed link to course terms rather than school setup

### DIFF
--- a/courses-and-sessions/courses/README.md
+++ b/courses-and-sessions/courses/README.md
@@ -38,7 +38,7 @@ This refers to the other course attributes listed below that can be maintained o
   - **[Objectives](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/courses/course_objectives):** maintain / manage objectives and their relationships to parent (program year) objectives, vocabulary terms, and MeSH terms
   - **[Learning Materials](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/courses/learning_materials):** upload and / or link course learning materials
   - **[Competencies](https://iliosproject.gitbook.io/ilios-user-guide/schools/competencies):** read-only display of competencies that are linked to the associated program year objectives 
-  - **[Terms](https://iliosproject.gitbook.io/ilios-user-guide/schools/vocabularies):** maintain vocabulary terms associated with this course
+  - **[Terms](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/courses/vocabulary_terms):** maintain vocabulary terms associated with this course
   - **[MeSH](https://iliosproject.gitbook.io/ilios-user-guide/additional-information/mesh):** maintain MeSH (Medical Subject Header) terms associated with this course
   - **[Program Cohorts](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/courses/course_actions/edit-course#program-cohorts):** maintain / manage cohort(s) attached to this course
 


### PR DESCRIPTION
The link on `courses/README.md` was incorrectly pointing to schools - this is regarding course vocabulary terms - new page was added recently so this link needed to be updated.