### PR TITLE
added output summary description to curriculum reports page

### DIFF
--- a/reports/curriculum_reports.md
+++ b/reports/curriculum_reports.md
@@ -44,3 +44,7 @@ The "copy link" button remains in this view, along with a "close" button just to
 If the download button is utilized, the user will be prompted like any other downloaded file as to where the .csv output is to be stored.
 
 The files will be downloaded with the following names ("objectives.csv" or "learner-groups.csv"). It is recommended to change the file names after downloading the data in order to keep everything straightened out. The names will download with file names such as "objectives(1).csv" and then "objectives(2)csv" if this is not done. This is for an output of the Objectives reports as an example. 
+
+## Output Fields 
+
+The Results Summary displays some informational summaries - rolled up data corresponding to the results of running the report. The downloaded .csv files, which can be opened and modified in Excel or other programs contains the detailed information at a much more granular level.


### PR DESCRIPTION
```
On branch update_reports_curriculum_reports_output_fields
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   reports/curriculum_reports.md
```

More is coming regarding this update - this sets up the place to put the .csv file download fields of the current Curriculum Reports.