### PR TITLE
this is a test - bold yes - colors no

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ In the following screenshot, I have navigated to the "Course Rollover" section o
 
 Breadcrumbs explained ...
 
-* <span style="color:red">**COURSE ACTIONS:** navigates up one level to "Course Actions" page</span>
+* **COURSE ACTIONS:** navigates up one level to "Course Actions" page
 * **COURSES:** navigates up two levels to "Courses" page 
 * **COURSES AND SESSIONS:** navigates up three levels back to the root of "Courses and Sessions"
 


### PR DESCRIPTION
```
On branch use_bold_for_now_colors_not_working
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   README.md
```

Reverting the code back to simply add **bold** to the breadcrumb link examples - I wanted Ilios orange coloring applied but for today will settle for simply bold. This PR cleans up the code.