### PR TITLE
removed now from a statement where it is no longer valid

### DIFF
--- a/courses-and-sessions/offerings/README.md
+++ b/courses-and-sessions/offerings/README.md
@@ -32,6 +32,6 @@ Click to add a new offering as shown by the arrow in the screen shot below. Firs
 
 ![Click button to start adding Offerings](../../images/offerings_README/add_new_offering_button.png)
 
-The screen now appears as shown below to continue taking action to add the offering(s). End Time is determined automatically based on the Duration of the Offering that is entered here. Also "Available Learner Groups" is a searchable field.
+The screen appears as shown below to continue taking action to add the offering(s). End Time is determined automatically based on the Duration of the Offering that is entered here. Also "Available Learner Groups" is a searchable field.
 
 ![Small Groups default shown](../../images/offerings_README/add_offering.png)


### PR DESCRIPTION
```
On branch eliminate_now_from_text_not_needed
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   courses-and-sessions/offerings/README.md
```

Updating this offering section in general, I noticed the phrase "now" appearing where it is not needed anymore - the entire section will be updated soon.