### PR TITLE
slight update to definition of session in glossary

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -82,7 +82,7 @@ An intermediate state of a Session or Course where some required elements are mi
 
 ## Session
 
-A session refers to a section or unit of a course with specific attributes of type and content. Sessions may be represented as multiple or singular time and place Offerings or as Independent Learning units with an estimated duration of educational time. Sessions (generally Independent Learning Modules (ILM's)) can be associated with a follow-up Session. These learning activities should be completed before the follow-up takes place, or by a specified Due Date and time.
+A session refers to a section or unit of a course with specific attributes of type and content. Sessions may be represented as multiple or singular time and place Offerings or as Independent Learning Modules (ILM's) with an estimated duration of educational time. Sessions (often Independent Learning Modules (ILM's)) can be associated with a follow-up Session. These learning activities should be completed before the follow-up takes place, or by a specified Due Date and time if they are not linked up.
 
 ## Vocabularies
 


### PR DESCRIPTION
This PR fixes the linked definition of "session" on the `glossary.md` page. ILM definition updated.