### PR TITLE
caption caps correction - heading update too

### DIFF
--- a/programs/add-program-year.md
+++ b/programs/add-program-year.md
@@ -1,4 +1,4 @@
-# Program Years
+# Program Years - defined
 
 A program year is essentially a year of instructional activity for any given program. The process of adding one or more program years is detailed below along with the configurable attributes of a program year.
 
@@ -53,17 +53,17 @@ To start with, navigate to Programs and select a Program. In this case, "Doctor 
 
 ## View Program Detail
 
-![Program detail](../images/programs/program_years/add_program_year_start.png)
+![program detail](../images/programs/program_years/add_program_year_start.png)
 
 ## Select Program Year
 
 For this example, and in order to show more detail in upcoming steps, Matriculation Year "2016-2017" with the Cohort of "Class of 2020" has been selected. At the time of this edit, those students will have recently graduated. This is useful in detailing Competency use throughout the student's educational trajectory. They will have already learned the Topics and Competencies on offer in the Program. Reporting out will provide more robust results.
 
-![Select program year](../images/programs/program_years/select_program_year.png)
+![select program year](../images/programs/program_years/select_program_year.png)
 
 Here is the resulting display after selecting "Class of 2020" as the Program Year. Editing a Program Year means utilizing the navigation shown below. 
 
-![Program year detail](../images/programs/program_years/program_year_detail.png)
+![program year detail](../images/programs/program_years/program_year_detail.png)
 
 When reviewing Program Year Objectives, you can not only download the Competency Map, you can review how these Program Year Objectives are mapped to Course Objectives as parents.
 


### PR DESCRIPTION
```
On branch replace_image_select_program_year
Changes to be committed:
        modified:   programs/add-program-year.md
```

Poorly named branch yet again - the image has not been replaced yet but a few captions were updated - need to start with not having "Program Years" needlessly duplicated at the top of the page. This is an interim PR - one that doesn't really fix much but does help prepare for future revamping of this entire Program Year area.