### PR TITLE
quick typo fix

### DIFF
--- a/programs/program-year-objective-map-visualization.md
+++ b/programs/program-year-objective-map-visualization.md
@@ -2,7 +2,7 @@
 
 This is a very dense and detailed visualizsation showing program year objectives being mapped down to the course and session level, indicating how this mapping has occured.
 
-It may be helpful to select a matriculation year with a considerable amount of data with a graduation year close to current year. This will help reflect the full curriculum in detail.
+It may be helpful to select a matriculation year with a considerable amount of data with a graduation year close to the current year. This will help reflect the full curriculum in detail.
 
 ![select visualization](../images/programs/objective_map_visualization/select_visualization.png)
 


### PR DESCRIPTION
Not much to see here. The text in Objective Visualization Program Year needed a "the" inserted to read accurately. This was added in this PR.