### PR TITLE
fixed links to match destinations

### DIFF
--- a/programs/edit-program.md
+++ b/programs/edit-program.md
@@ -2,10 +2,10 @@
 
  As far as the Program itself is concerned, the fields that can be modified are listed below along with detail links. Editing any of these fields will have long reaching effects.
 
-* [Title](https://iliosproject.gitbook.io/ilios-user-guide/programs/edit-program#edit-title)
-* [Short Title](https://iliosproject.gitbook.io/ilios-user-guide/programs/edit-program#add-edit-short-title)
-* [Duration (in years)](https://iliosproject.gitbook.io/ilios-user-guide/programs/edit-program#update-duration-years)
-* [Leadership](https://iliosproject.gitbook.io/ilios-user-guide/programs/edit-program#update-leadership) - (add/remove Directors)
+* [Edit Title](https://iliosproject.gitbook.io/ilios-user-guide/programs/edit-program#edit-title)
+* [Add / Edit Short Title](https://iliosproject.gitbook.io/ilios-user-guide/programs/edit-program#add-edit-short-title)
+* [Update Duration (Years)](https://iliosproject.gitbook.io/ilios-user-guide/programs/edit-program#update-duration-years)
+* [Update Leadership](https://iliosproject.gitbook.io/ilios-user-guide/programs/edit-program#update-leadership) - (add/remove Directors)
 
 ![program - high level view](../images/programs/edit_program/program_high_level_view.png)
 


### PR DESCRIPTION
```
On branch update_edit_title_program_year_to_match
Changes to be committed:
        modified:   programs/edit-program.md
```

This was actually an update to "programs" not "program year" - branch not named correctly in this case.