### PR TITLE
added page and added link course MeSH

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -36,6 +36,7 @@
       * [View Learning Materials](courses-and-sessions/courses/view-learning-materials.md)
     * [Competencies](courses-and-sessions/courses/competencies.md)
     * [Vocabulary Terms](courses-and-sessions/courses/vocabulary_terms.md)
+    * [MeSH Terms](courses-and-sessions/courses/MeSH_terms.md)
     * [Course Actions](courses-and-sessions/courses/course_actions.md)
       * [Create New Course](courses-and-sessions/courses/create-new-course.md)
       * [Edit Course](courses-and-sessions/courses/edit-course.md)

--- a/courses-and-sessions/courses/MeSH_terms.md
+++ b/courses-and-sessions/courses/MeSH_terms.md
@@ -1,0 +1,2 @@
+A quick reference to MeSH terms is linked [here](https://iliosproject.gitbook.io/ilios-user-guide/additional-information/mesh). The full process of attaching MeSH to a Course in Ilios will be covered on this page. 
+


### PR DESCRIPTION
```
On branch create_page_for_course_MeSH
Changes to be committed:
        modified:   SUMMARY.md
        new file:   courses-and-sessions/courses/MeSH_terms.md
```

This PR creates the page for course level MeSH - MeSH is covered in the guide but not explicitly at the course level. That will be done upcoming. The MeSH page is linked in the initial text of the page. Link added to summary.md to create the chapter.