### PR TITLE
added page and added link course MeSH update

### DIFF
--- a/courses-and-sessions/courses/MeSH_terms.md
+++ b/courses-and-sessions/courses/MeSH_terms.md
@@ -1,2 +1,1 @@
-A quick reference to MeSH terms is linked [here](https://iliosproject.gitbook.io/ilios-user-guide/additional-information/mesh). The full process of attaching MeSH to a Course in Ilios will be covered on this page. 
-
+A quick reference to MeSH terms is located [here](https://iliosproject.gitbook.io/ilios-user-guide/additional-information/mesh).


### PR DESCRIPTION
Shortened the temporary introduction spiel on recently created course MeSH page. More is coming soon but that reference was not necessary in the guide since a link was provided for reference to MeSH for now.