### PR TITLE
added section for click to manage to session MeSH

### DIFF
--- a/courses-and-sessions/sessions/manage_MeSH.md
+++ b/courses-and-sessions/sessions/manage_MeSH.md
@@ -6,6 +6,8 @@ MeSH terms can be mainatained at the session level as well. Refer to [this](http
 
 To add a MeSH Term to a Session, follow the steps below. The steps for adding MeSH are the same wherever MeSH (Medical Subject Headers) can be attached - Sessions, Courses, Learning Materials, and Objectives.
 
+### Click to Manage
+
 ![click manage MeSH to start](../../images/session_edit/click_to_manage_mesh.png)
 
 In the case of searching for MeSH, it is necessary to hit the Enter key on the keyboard to run the search. This is because there is a large data set of MeSH terms so it is necessary to run a special query in this manner.


### PR DESCRIPTION
```
On branch add_click_to_manage_add_sess_MeSH
Changes to be committed:
        modified:   courses-and-sessions/sessions/manage_MeSH.md
```

This PR standardizes the formatting a bit on the session manage MeSH page - more consistent headers now present.