### PR TITLE
three failed attempts at target =_blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Welcome to the official Ilios User Guide. Feel free to bookmark this page and re
 
 # Sign up for Updates
 
-For an introduction to Ilios and to sign up for newsletters and announcements, click [here](https://www.iliosproject.org/about/){:target="_blank"}. Once on that page, select "Status Reports" and then click "join our mailing list". A form will appear requiring that you enter your email address and first and last name. A confirmation email message will be sent to the email address entered. This is required to confirm your subscription. We highly recommend subscribing to get the latest news. Subscription options are shown below.
+For an introduction to Ilios and to sign up for newsletters and announcements, click [here](https://www.iliosproject.org/about/). Once on that page, select "Status Reports" and then click "join our mailing list". A form will appear requiring that you enter your email address and first and last name. A confirmation email message will be sent to the email address entered. This is required to confirm your subscription. We highly recommend subscribing to get the latest news. Subscription options are shown below.
 
 ![sign up for updates](images/introduction/subscription_options.png)
 


### PR DESCRIPTION
```
On branch revert_back
Changes to be committed:
        modified:   README.md
```

Here's a ticket that might help but will ask about this if I remember. I wanted to have the sign up for updates follow the target = _blank route but a cpl of efforts failed at doing this. The HTML was fine - I tested it but it didn't work in GitBook flavored Markdown - tried a cpl of regular Markdown suggested fixes but no dice ... yet.