### PR TITLE
flattened link sizes to be all the same

### DIFF
--- a/programs/README.md
+++ b/programs/README.md
@@ -24,7 +24,7 @@ A newly-entered Program will need to have Program Year(s) set up in order to ass
 
 ## [Program Years](https://iliosproject.gitbook.io/ilios-user-guide/programs/add-program-year)
 
-### [Competency Map Download](https://iliosproject.gitbook.io/ilios-user-guide/programs/competency-map-download)
+## [Competency Map Download](https://iliosproject.gitbook.io/ilios-user-guide/programs/competency-map-download)
 
-### [Program Year Objectives Visualization](https://iliosproject.gitbook.io/ilios-user-guide/programs/program-year-objective-map-visualization)
+## [Program Year Objectives Visualization](https://iliosproject.gitbook.io/ilios-user-guide/programs/program-year-objective-map-visualization)
 


### PR DESCRIPTION
```
On branch fix_link_sizes_program_README
Changes to be committed:
        modified:   programs/README.md
```

Even though I wanted to have indented links, it looks better since the indentation wasn't initially possible, to have them all at the same size. It looks better this way.