### PR TITLE
after image replaced - text modification

### DIFF
--- a/courses-and-sessions/offerings/create-small-group-offerings.md
+++ b/courses-and-sessions/offerings/create-small-group-offerings.md
@@ -36,11 +36,11 @@ Search for and choose "Demo Group" from the "Available Learner Groups" grid as s
 
 ![select parent group](../../images/create_small_group_offerings/select_parent_group.png)
 
-Once the higher level "Demo Group" group has been selected, all of its sub-groups are now in the "Selected" column and are ready to have the small group session events created. Also there is a badge to indicate the higher level, parent group `"Demo Group "` which indicates that the parent group has zero members added at that level. Each subgroup has a similar badge with member count included, where applicable.
+Once the higher level "Demo Group" group has been selected, all of its subgroups are now in the "Selected" column and are ready to have the small group session events created. Also there is a badge to indicate the higher level, parent group `"Demo Group "` which indicates that the parent group has zero members added at that level. Each subgroup has a similar badge with member count included, where applicable.
 
 ![learner groups added](../../images/create_small_group_offerings/learner_groups_added.png)
 
-Now we are in the position to create a separate event for each of the eight sub-groups in the "Selected" pane as well as an offering for the parent group "Demo Group".
+Now we are in the position to create a separate event for each of the eight subgroups in the "Selected" pane as well as an offering for the parent group "Demo Group".
 
 **NOTE:** An offering will be created for the parent group if the parent group remains selected. The parent group (or any group at any level) can be removed holding the Shift key down and selecting the parent group either in the list or on its badge. 
 


### PR DESCRIPTION
```
On branch replace_offering_editor_parent_group_description
Changes to be committed:
        modified:   courses-and-sessions/offerings/create-small-group-offerings.md
```

Since this has changed - parent group badges no longer count up the sum of the membership of all sub groups combined - it was necessary to add that to the guide.