### PR TITLE
added a bit  of text for better clarification hopefully

### DIFF
--- a/courses-and-sessions/offerings/create-small-group-offerings.md
+++ b/courses-and-sessions/offerings/create-small-group-offerings.md
@@ -36,7 +36,7 @@ Search for and choose "Demo Group" from the "Available Learner Groups" grid as s
 
 ![select parent group](../../images/create_small_group_offerings/select_parent_group.png)
 
-Once the higher level "Demo Group" group has been selected, all of its subgroups are now in the "Selected" column and are ready to have the small group session events created. Also there is a badge to indicate the higher level, parent group `"Demo Group"` which indicates that the parent group is included but has zero members added to that exact group. Each subgroup has a similar badge with member count included. If a subgroup has no members, it will be displayed with "(0)" appended to its badge.
+Once the higher level "Demo Group" group has been selected, all of its subgroups are now in the "Selected" column and are ready to have the small group session events created. Also there is a badge to indicate the higher level, parent group `"Demo Group"` which indicates that the parent group is included but has zero members added to that exact group. Each subgroup has a similar badge with member count included. If a subgroup has no members, it will be displayed with "(0)" appended to its badge. Parent groups also receive the "(x)" signage but only when the parent group has members directly assigned to it.
 
 ![learner groups added](../../images/create_small_group_offerings/learner_groups_added.png)
 


### PR DESCRIPTION
```
On branch one_more_explanation_about_membership
Changes to be committed:
        modified:   courses-and-sessions/offerings/create-small-group-offerings.md
```

It's a strange world out there with the labeling of group membership counts in the offering manager. This PR adds the logic that parent groups only have count values appended if there are members attached at that level. I tested this to determine its accuracy.