### PR TITLE
caption fixed to match file name

### DIFF
--- a/learner-groups/edit-group-properties/edit-group-membership.md
+++ b/learner-groups/edit-group-properties/edit-group-membership.md
@@ -8,7 +8,7 @@ In this example, there are no Learners in the group "Demonstration Group 5". The
 
 Once the green (+) has been clicked to add "Robin Alvarez" to the sub group "Demonstration Group 5", the screen updates to what is shown below and it is easy to verify the learner's enrollment in the group.
 
-![added to the learner group](../../images/edit_learner_group/group_membership/learner_added.png)
+![learner added](../../images/edit_learner_group/group_membership/learner_added.png)
 
 ### Multiple Learners
 


### PR DESCRIPTION
```
On branch manage_learner_group_caption_match
Changes to be committed:
        modified:   learner-groups/edit-group-properties/edit-group-membership.md
```

Whenever possible, I am having the captions to images directly match the file names - hoping this will help keep things straight going forward. This PR is an example of that.