### PR TITLE
caption fixed capitalization updated lower case

### DIFF
--- a/learner-groups/edit-group-properties/edit-group-membership.md
+++ b/learner-groups/edit-group-properties/edit-group-membership.md
@@ -16,14 +16,14 @@ Users will need to scroll down to the lower part of the screen to access the are
 
 In this example the filtering functionality was not used; but it is evident that five Learners have been selected using the check boxes provided and can now be moved into the learner group "Demonstration Group 5" with one button click.
 
-![Add multiple learners](../../images/edit_learner_group/group_membership/add_multiple_learners.png)
+![add multiple learners](../../images/edit_learner_group/group_membership/add_multiple_learners.png)
 
 ## Remove Learners from Group
 
 ### Individual Learner
 Below is a screen shot depicting a learner group in "Manage" mode. Before any learners have been selected using the check boxes on the left, there are red indicators available to remove any one learner immediately. This happens without confirmation. As an example, the learner "Ann Cheryl Rose" will be removed from the learner group as soon as the red line is clicked.
 
-![Remove one learner](../../images/edit_learner_group/group_membership/remove_one_learner.png)
+![remove one learner](../../images/edit_learner_group/group_membership/remove_one_learner.png)
 
 It is necessary (as in the "add" actions performed above) to click "Manage" after navigating to the correct learner group/sub group to perform maintenance.
 
@@ -38,7 +38,7 @@ Learners to be removed ...
 * "Kathy Jason Frazier"
 * "Keith Virginia Stewart"
 
-![Remove multiple learners](../../images/edit_learner_group/group_membership/remove_multiple_learners.png)
+![remove multiple learners](../../images/edit_learner_group/group_membership/remove_multiple_learners.png)
 
 ### Search for Learner(s)
 


### PR DESCRIPTION
```
On branch another_caption_fix_remove_learners_learner_group
Changes to be committed:
        modified:   learner-groups/edit-group-properties/edit-group-membership.md
```

Similar to #1755 this one fixes the captions following a self-imposed standard of not using capital letters in the captions. This PR cleans up the `edit-group-membership.md` file in a couple of places.