### PR TITLE
made a copy of session-objectives.md into objectives.md

### DIFF
--- a/courses-and-sessions/sessions/objectives.md
+++ b/courses-and-sessions/sessions/objectives.md
@@ -1,0 +1,13 @@
+---
+description: Objectives can be attached to courses, sessions, or program years. The process of creating and modifiying session objectives is covered below.
+---
+
+[Add Objective](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions/objectives/add-session-objective)
+
+[Edit Objectives](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions/objectives/edit-session-objective)
+
+[Attach Parent Objective(s)](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions/objectives/add-parent-objective-s)
+
+[Update Parent Objective(s)](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions/objectives/edit-parent-objective-s)
+
+[Sort Objectives](https://iliosproject.gitbook.io/ilios-user-guide/courses-and-sessions/sessions/objectives/sort-objectives)


### PR DESCRIPTION
I'm actually super-confused about what's going on right now. Session Objectives appears to point to `objectives.md` at the `courses-and-sessions/sessions` level but I can't find that file anywhere and have been messing with `session-objectives.md` so in a probably bone-headed maneuver I attempted to make a copy of `session-objectives.md` and save it as `objectives.md` to see what will happen - this is that experiment.