### PR TITLE
select terms caption formatted correctly

### DIFF
--- a/schools/vocabularies.md
+++ b/schools/vocabularies.md
@@ -137,7 +137,7 @@ For this example, we would like to add descriptive content to a DEI Term "Cultur
 
 ### Select Term
 
-![Select term](../images/schools/vocabularies/select_term.png)
+![select term](../images/schools/vocabularies/select_term.png)
 
 ### Add Description
 


### PR DESCRIPTION
```
On branch fix_select_term_caption_to_match
Changes to be committed:
        modified:   schools/vocabularies.md
```