### PR TITLE
redoing calendar filter / search options part two

### DIFF
--- a/dashboard/calendar-search-and-filter-options.md
+++ b/dashboard/calendar-search-and-filter-options.md
@@ -22,7 +22,7 @@ The toggles now appear as shown below with the filters activated and visible.
 
 ![filters displayed](../images/calendar_srch_images/filters_displayed.png)
 
-### By Course / Session Type
+### Course / Session Type
 
 This search option allows the user to search and display all of the activities for any course in the selected academic year and school. That course selection can be further filtered for specific session types.
 
@@ -38,7 +38,7 @@ In order to see all of the Sessions related to the Airways, Blood, and Circulati
 
 In any of these search modes, a search is automatically performed once the corresponding check boxes have been selected. The Calendar will reload with the results.
 
-### By Program Detail
+### Program Detail
 
 Switch to a "Program Detail" search as shown below.
 


### PR DESCRIPTION
```
On branch make_sure_cal_search_options_match_screen_2
Changes to be committed:
        modified:   dashboard/calendar-search-and-filter-options.md
```

This PR ensures that the H3 section caption accurately match the captions bolded above and exactly what is currently displayed on the Ilios calendar.