### PR TITLE
glossary update - removed student advisor

### DIFF
--- a/dashboard/my-profile.md
+++ b/dashboard/my-profile.md
@@ -22,7 +22,7 @@ This screen is informational only - except for the API Token Management, which i
 * **Former Student** - indicates when the logged in user is (was) a Student who has graduated.  This information can be obtained via a nightly synchronization job with your directory server.
 * **Account Enabled** - read-only display of the status of the logged-in user's account (will always be "Yes" in this context) - modified in the Admin Console 
 * **Exclude From Sync** - selected when this user is to be considered an exception regarding the synchronization job. If this is the case, Ilios retains its data and overwrite attempts are not performed based on data coming from the directory server.
-* **Performs Non-Learner Functions** - indicates if this user has been attached to any learning activity ever as a "non-learner", typically as an Instructor, Administrator, Director, or Student Advisor
+* **Performs Non-Learner Functions** - indicates if this user has been attached to any learning activity ever as a "non-learner", typically as an Instructor, Administrator, or Director
 * **Learner** - indicates anyone who has ever been assigned to “learn” in an activity or session - not necessarily an enrolled cohort member derived from the campus system of record or SIS (Student Information System)
 * **Root** - indicates if this user has `root` level permissions (the highest) for the Ilios system at this School's implementation.
 


### PR DESCRIPTION
```
On branch remove_student_advisor_from_performs_non_learner_functions
Changes to be committed:
        modified:   dashboard/my-profile.md
```

The student advisor role was included in the performs non-learner activity flag definition. This is not true. This PR fixes that aspect of that relationship. 

