### PR TITLE
updated text

### DIFF
--- a/dashboard/calendar-feed-options.md
+++ b/dashboard/calendar-feed-options.md
@@ -31,7 +31,7 @@ To connect a calendar application with Ilios, you will need a unique URL that yo
 
 **NOTE:** The Calendar feed includes data which spans the time frame of 4 months prior to the current date until two months after the current date. Calendar items that fall outside of that time range or that are in Draft mode will not appear in the feed.
 
-**Step One:** Make sure to select Calendar and then click the Feed icon to generate the Calendar's URL feed.
+**Step One:** Click the Feed icon to generate the Calendar's URL feed.
 
 ![generate the feed](../images/calendar_feed_options/generate_the_feed.png)
 


### PR DESCRIPTION
```
On branch update_image_calendar_feed_options_continue
Changes to be committed:
        modified:   dashboard/calendar-feed-options.md
```

The text on this page has been updated - you can be on any screen and retrieve your calendar feed - no longer need to be on calendar itself. This PR updates that in the guide.