### PR TITLE
text updated courses README - rework in progress

### DIFF
--- a/courses-and-sessions/courses/README.md
+++ b/courses-and-sessions/courses/README.md
@@ -14,8 +14,7 @@ This area appears at the top of the Course page. It includes everything listed b
   - **Title:** can be edited here - refers to full title (name) of the course, entered on course creation - 200 character maximum
   - **Publication Status:** This is a drop-down menu containing the options for publishing a course - listed below.
     - **Not Published:** initial status at course creation time - can be returned to this later by using **UnPublish**
-    - **Publish** or **Publish As-Is:** publishes course 
-    - **Review Missing Items:** review desired or required items for course publication
+    - **Publish** or **Publish As-Is:** publishes course after reviewing any missing requested items
     - **Mark as Scheduled:** sets course to `Scheduled` status
     - **UnPublish:** only available if course has been published - reverts course to `Not Published` status 
 


### PR DESCRIPTION
```
On branch start_work_on_courses_revamp_text_update
Changes to be committed:
        modified:   courses-and-sessions/courses/README.md
```

Removes reference to the option "review (x) missing items" - this caption has been removed from the drop-down. Possibly not merged into production yet - true - but I figured fix up the documentation in here while I'm at it.